### PR TITLE
v0.7.7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group 'com.acme'
-version '0.7.5'
+version '0.7.6'
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/acme/json/helper/core/parser/JsonNodeParser.java
+++ b/src/main/java/com/acme/json/helper/core/parser/JsonNodeParser.java
@@ -24,7 +24,12 @@ public class JsonNodeParser {
      * @return {@link JsonNode }
      */
     public static JsonNode parse(final String key, final String json) {
-        return parseNode(key, JSON.parse(json));
+        return parseNode(key,
+                Opt.of(JSON.isValid(json))
+                        .filter(i -> i)
+                        .map(item -> JSON.parse(json))
+                        .orElse(json)
+        );
     }
 
     /**

--- a/src/main/java/com/acme/json/helper/ui/panel/JsonTreePanel.java
+++ b/src/main/java/com/acme/json/helper/ui/panel/JsonTreePanel.java
@@ -27,7 +27,7 @@ import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.util.Map;
 import java.util.Objects;
-import java.util.stream.IntStream;
+import java.util.ResourceBundle;
 
 /**
  * JSON树面板
@@ -37,6 +37,10 @@ import java.util.stream.IntStream;
  */
 public class JsonTreePanel extends JPanel {
     private final Tree jsonTree;
+    /**
+     * 加载语言资源文件
+     */
+    private static final ResourceBundle BUNDLE = ResourceBundle.getBundle("messages.JsonHelperBundle");
 
     public JsonTreePanel() {
         super(new BorderLayout());
@@ -53,7 +57,6 @@ public class JsonTreePanel extends JPanel {
         jsonTree.setModel(new DefaultTreeModel(buildTreeModel(
                 JsonNodeParser.parse("root", txt)
         )));
-        IntStream.range(0, jsonTree.getRowCount()).forEach(jsonTree::expandRow);
     }
 
     /**
@@ -150,7 +153,7 @@ public class JsonTreePanel extends JPanel {
     private void addRightClickMenuToTree(final Tree tree) {
         // 创建右键菜单
         final JPopupMenu popupMenu = new JPopupMenu();
-        final JMenuItem copyItem = new JMenuItem("Copy");
+        final JMenuItem copyItem = new JMenuItem(BUNDLE.getString("json.tree.copy"));
         // 复制动作实现
         copyItem.addActionListener(e -> {
             final TreePath path = tree.getSelectionPath();

--- a/src/main/resources/messages/JsonHelperBundle.properties
+++ b/src/main/resources/messages/JsonHelperBundle.properties
@@ -1,3 +1,4 @@
+json.tree.copy=copy
 json.new.tab=New Tab
 json.new.tab.desc=Open new JSON editor tab
 json.format.json=Format JSON

--- a/src/main/resources/messages/JsonHelperBundle_zh_CN.properties
+++ b/src/main/resources/messages/JsonHelperBundle_zh_CN.properties
@@ -1,3 +1,4 @@
+json.tree.copy=\u590D\u5236
 json.new.tab=\u65B0\u6807\u7B7E\u9875
 json.new.tab.desc=\u6253\u5F00\u65B0\u7684JSON\u7F16\u8F91\u5668\u9009\u9879\u5361
 json.format.json=\u683C\u5F0F\u5316JSON


### PR DESCRIPTION
fix: 🪲️修复 JSON节点解析器导致的JSON编辑器联动错误
fix: 🪲️修复 创建新编辑器标签页并写入JSON时，无内容以及无法自动定位到新标签问题
perf: 📜️调整 JSON树面板不会再自动展开所有节点
build: ️️️版本提升 0.7.5 -> 0.7.7