### PR TITLE
v0.7.11.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group 'com.acme'
-version '0.7.11.3'
+version '0.7.11.4'
 
 repositories {
     mavenCentral()
@@ -21,6 +21,12 @@ java {
     targetCompatibility = JavaVersion.VERSION_21
 }
 
+ext {
+    hutoolVersion = '5.8.37'
+    jacksonVersion = '2.19.0'
+    fastjson2Version = '2.0.57'
+}
+
 dependencies {
     intellijPlatform {
         intellijIdeaCommunity '2025.1'
@@ -31,13 +37,13 @@ dependencies {
         bundledPlugin 'com.intellij.modules.json'
         bundledPlugin 'org.jetbrains.plugins.yaml'
     }
-    implementation 'cn.hutool:hutool-core:5.8.37'
-    implementation 'cn.hutool:hutool-http:5.8.37'
-    implementation 'com.alibaba.fastjson2:fastjson2:2.0.57'
-    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.18.3'
-    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-toml:2.18.3'
-    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.18.3'
-    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-properties:2.18.3'
+    implementation "cn.hutool:hutool-core:${hutoolVersion}"
+    implementation "cn.hutool:hutool-http:${hutoolVersion}"
+    implementation "com.alibaba.fastjson2:fastjson2:${fastjson2Version}"
+    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-xml:${jacksonVersion}"
+    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-toml:${jacksonVersion}"
+    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${jacksonVersion}"
+    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-properties:${jacksonVersion}"
 }
 
 runIde {


### PR DESCRIPTION
build: 更新版本号并优化依赖管理
    - 将项目版本号从 0.7.11.3 升级到 0.7.11.4
    - 引入 ext 代码块统一管理依赖版本号 
build: 🔨版本提升 0.7.11.3 -> 0.7.11.4