### PR TITLE
fix: 修复彩虹高亮监听器 DocumentListener 双重移除异常，发布 0.17.1-0.17.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,10 +74,9 @@ intellijPlatform {
         // sinceBuild 自 IGP 2.14 起默认取目标平台 major build（2026.2 → 262），无需显式声明
         changeNotes = """
             <ul>
-                <li>新增彩虹变量高亮：Java 方法内参数与局部变量按名稳定着色，支持浅色/深色主题双变体，设置面板可开关。</li>
-                <li>新增颜色字面量高亮：识别 #RGB/#RRGGBB(#AA)/rgb()/rgba() 颜色字面量并在行号栏显示色块，点击色块弹出调色板修改并回写。</li>
-                <li>两个功能均后台线程分析、300ms 防抖、EDT 仅做绘制，大文件自动跳过，不影响 IDE 流畅度。</li>
-                <li>修复索引未就绪时变量着色触发 IndexNotReadyException 的问题（改走 smart mode 排队执行）。</li>
+                <li>修复彩虹变量高亮监听器在项目关闭时因 DocumentListener 双重移除导致的 "Can't remove document listener" 异常。</li>
+                <li>移除 addDocumentListener 的 parent disposable，生命周期统一由 EditorFactoryListener.editorReleased 显式管理。</li>
+                <li>增加 disposed 标志防止 dispose 被重复调用。</li>
             </ul>
         """.stripIndent()
     }

--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,7 @@ intellijPlatform {
         // sinceBuild 自 IGP 2.14 起默认取目标平台 major build（2026.2 → 262），无需显式声明
         changeNotes = """
             <ul>
-                <li>修复彩虹变量高亮监听器在项目关闭时因 DocumentListener 双重移除导致的 "Can't remove document listener" 异常。</li>
+                <li>修复颜色字面量高亮监听器在项目关闭时因 DocumentListener 双重移除导致的 "Can't remove document listener" 异常。</li>
                 <li>移除 addDocumentListener 的 parent disposable，生命周期统一由 EditorFactoryListener.editorReleased 显式管理。</li>
                 <li>增加 disposed 标志防止 dispose 被重复调用。</li>
             </ul>

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 // 统一版本表：插件版本、目标平台、Java 基线与第三方依赖版本在此集中维护
 gradle.ext.versions = [
         // 插件版本：发布新版本时递增，并同步更新 build.gradle 中的 changeNotes
-        ver         : "0.17.1",
+        ver         : "0.17.2",
         // 目标 IntelliJ 平台版本：sinceBuild 自 IGP 2.14 起默认取平台 major build（2026.2 → 262），无需显式声明
         idea        : "2026.2",
         // Java 语言基线：toolchain 与 options.release 共用

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 // 统一版本表：插件版本、目标平台、Java 基线与第三方依赖版本在此集中维护
 gradle.ext.versions = [
         // 插件版本：发布新版本时递增，并同步更新 build.gradle 中的 changeNotes
-        ver         : "0.17.0",
+        ver         : "0.17.1",
         // 目标 IntelliJ 平台版本：sinceBuild 自 IGP 2.14 起默认取平台 major build（2026.2 → 262），无需显式声明
         idea        : "2026.2",
         // Java 语言基线：toolchain 与 options.release 共用

--- a/src/main/java/com/acme/json/helper/core/rainbow/ColorHighlightListener.java
+++ b/src/main/java/com/acme/json/helper/core/rainbow/ColorHighlightListener.java
@@ -69,6 +69,7 @@ final class ColorHighlightListener implements DocumentListener {
     private final ProjectDisposableService disposable;
     private final Alarm refreshAlarm;
     private final List<RangeHighlighter> activeHighlighters = new ArrayList<>();
+    private volatile boolean disposed;
 
     /**
      * 构造监听器并注册到编辑器。
@@ -83,7 +84,8 @@ final class ColorHighlightListener implements DocumentListener {
         this.disposable = ProjectDisposableService.getInstance(project);
         // 池化线程 Alarm：扫描在后台线程执行，不占用 EDT
         this.refreshAlarm = new Alarm(Alarm.ThreadToUse.POOLED_THREAD, disposable);
-        document.addDocumentListener(this, disposable);
+        // 生命周期由 EditorFactoryListener.editorReleased 显式管理，不挂 parent disposable 避免双重移除
+        this.document.addDocumentListener(this);
         scheduleRefresh();
     }
 
@@ -96,6 +98,10 @@ final class ColorHighlightListener implements DocumentListener {
      * 清理监听器、取消防抖任务并移除全部高亮。
      */
     void dispose() {
+        if (disposed) {
+            return;
+        }
+        disposed = true;
         refreshAlarm.cancelAllRequests();
         document.removeDocumentListener(this);
         clearHighlighters();

--- a/src/main/java/com/acme/json/helper/core/rainbow/RainbowVariableHighlighter.java
+++ b/src/main/java/com/acme/json/helper/core/rainbow/RainbowVariableHighlighter.java
@@ -67,6 +67,7 @@ final class RainbowVariableHighlighter implements DocumentListener {
     private final Document document;
     private final Alarm refreshAlarm;
     private final List<RangeHighlighter> activeHighlighters = new ArrayList<>();
+    private volatile boolean disposed;
 
     /**
      * 构造监听器并注册到编辑器文档。
@@ -80,8 +81,8 @@ final class RainbowVariableHighlighter implements DocumentListener {
         this.document = editor.getDocument();
         // 后台线程 Alarm：防抖回调直接在池线程执行，PSI 遍历不占用 EDT
         this.refreshAlarm = new Alarm(Alarm.ThreadToUse.POOLED_THREAD, ProjectDisposableService.getInstance(project));
-        // 随项目销毁自动注销，dispose 中的显式移除作为兜底
-        this.document.addDocumentListener(this, ProjectDisposableService.getInstance(project));
+        // 生命周期由 EditorFactoryListener.editorReleased 显式管理，不挂 parent disposable 避免双重移除
+        this.document.addDocumentListener(this);
         // 延迟调度首次刷新，避免在编辑器尚未初始化完成时访问 PSI
         scheduleRefresh();
     }
@@ -95,6 +96,10 @@ final class RainbowVariableHighlighter implements DocumentListener {
      * 清理监听器和高亮。
      */
     void dispose() {
+        if (disposed) {
+            return;
+        }
+        disposed = true;
         document.removeDocumentListener(this);
         refreshAlarm.cancelAllRequests();
         clearHighlighters();


### PR DESCRIPTION
## 修复

项目关闭时 `RainbowVariableHighlighter` 与 `ColorHighlightListener` 因 `DocumentListener` 被 parent disposable 自动移除后，`editorReleased` 又显式移除，导致 `Can't remove document listener`。

- 移除 `addDocumentListener` 的 parent disposable，生命周期统一由 `editorReleased` 管理
- 增加 `disposed` 标志防重复调用
- 已全量检查其他 `DocumentListener` 使用位置，无同类问题

包含 `0.17.1`（变量高亮）与 `0.17.2`（颜色高亮）两个修复。
