### PR TITLE
fix: 修复默认隐藏原始滚动条在部分编辑器不生效，发布 0.18.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,10 @@ intellijPlatform {
         version = project.version.toString()
         // sinceBuild 自 IGP 2.14 起默认取目标平台 major build（2026.2 → 262），无需显式声明
         changeNotes = """
+            <b>0.18.2</b>
+            <ul>
+                <li>修复默认隐藏原始滚动条在部分编辑器（Json Helper 面板、git diff 视图等）不生效：编辑器创建后平台仍会初始化滚动条配置覆盖宽度归零，现于 EDT 队尾补应用一次。</li>
+            </ul>
             <b>0.18.1</b>
             <ul>
                 <li>修复新建空文件或编辑器初始化瞬态，代码地图渲染偶发数组越界异常。</li>

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 // 统一版本表：插件版本、目标平台、Java 基线与第三方依赖版本在此集中维护
 gradle.ext.versions = [
         // 插件版本：发布新版本时递增，并同步更新 build.gradle 中的 changeNotes
-        ver         : "0.18.1",
+        ver         : "0.18.2",
         // 目标 IntelliJ 平台版本：sinceBuild 自 IGP 2.14 起默认取平台 major build（2026.2 → 262），无需显式声明
         idea        : "2026.2",
         // Java 语言基线：toolchain 与 options.release 共用

--- a/src/main/java/com/acme/json/helper/core/minimap/MinimapEditorFactoryListener.java
+++ b/src/main/java/com/acme/json/helper/core/minimap/MinimapEditorFactoryListener.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
+import javax.swing.SwingUtilities;
 
 /**
  * 编辑器工厂监听器：编辑器创建时在右侧挂载代码缩略图面板，释放时移除并 dispose。
@@ -140,6 +141,13 @@ public final class MinimapEditorFactoryListener implements EditorFactoryListener
         panelRef.set(panel);
         editor.getComponent().add(panel, BorderLayout.LINE_END);
         applyScrollBarVisibility(editor, PluginSettingsState.getInstance().minimapHideOriginalScrollBar);
+        // EditorTextField（Json Helper 面板）、diff 视图等在 editorCreated 之后才完成自身滚动条配置
+        //（策略与尺寸初始化会覆盖宽度归零），EDT 队尾补应用一次，保证默认隐藏不依赖创建时机
+        SwingUtilities.invokeLater(() -> {
+            if (!editor.isDisposed() && PANELS.containsKey(editor)) {
+                applyScrollBarVisibility(editor, PluginSettingsState.getInstance().minimapHideOriginalScrollBar);
+            }
+        });
         return panel;
     }
 }


### PR DESCRIPTION
- EditorTextField（Json Helper 面板）、diff 视图等在 editorCreated 之后才完成自身滚动条配置，初始化覆盖宽度归零
- 挂载时首次归零后于 EDT 队尾补应用一次，默认隐藏不再依赖创建时机