### PR TITLE
fix: 修复项目搜索打开项目时 UI 冻结死锁，发布 0.18.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,10 @@ intellijPlatform {
         version = project.version.toString()
         // sinceBuild 自 IGP 2.14 起默认取目标平台 major build（2026.2 → 262），无需显式声明
         changeNotes = """
+            <b>0.18.8</b>
+            <ul>
+                <li>修复项目搜索打开项目时 UI 冻结死锁：itemSelected 回调在写意图读锁上下文执行，同步 openOrImport 与新项目打开所需写锁互等，改为投递 EDT 队列尾部脱离锁上下文后打开。</li>
+            </ul>
             <b>0.18.7</b>
             <ul>
                 <li>修复代码地图异味/警告条纹不显示：很多检查只配波浪线颜色不配 error-stripe 色，现颜色回退链补全（error-stripe 色 → 文本属性 → 波浪线效果色），高亮源合并文档 MarkupModel，条纹强制全色整行高亮。</li>

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 // 统一版本表：插件版本、目标平台、Java 基线与第三方依赖版本在此集中维护
 gradle.ext.versions = [
         // 插件版本：发布新版本时递增，并同步更新 build.gradle 中的 changeNotes
-        ver         : "0.18.7",
+        ver         : "0.18.8",
         // 目标 IntelliJ 平台版本：sinceBuild 自 IGP 2.14 起默认取平台 major build（2026.2 → 262），无需显式声明
         idea        : "2026.2",
         // Java 语言基线：toolchain 与 options.release 共用

--- a/src/main/java/com/acme/json/helper/core/search/ProjectSearch.java
+++ b/src/main/java/com/acme/json/helper/core/search/ProjectSearch.java
@@ -12,6 +12,7 @@ import com.intellij.icons.AllIcons;
 import com.intellij.ide.actions.searcheverywhere.FoundItemDescriptor;
 import com.intellij.ide.actions.searcheverywhere.WeightedSearchEverywhereContributor;
 import com.intellij.ide.impl.ProjectUtil;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.progress.ProcessCanceledException;
 import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.progress.ProgressManager;
@@ -208,7 +209,11 @@ public record ProjectSearch(Project project) implements WeightedSearchEverywhere
         if (item instanceof ProjectNavigationItem.GitRepository git) {
             this.cloneIfNotExist(git.repositoryUrl());
         } else {
-            ProjectUtil.openOrImport(item.projectPath(), null, Boolean.FALSE);
+            // 本回调在 Search Everywhere 的写意图读锁上下文（Dispatchers.EDT + write-intent read）中执行：
+            // 同步 openOrImport 会就地起模态进度，新项目打开需写锁，与持有的写意图读互等死锁（UI 冻结）。
+            // 投递到 EDT 队列尾部、脱离锁上下文后再打开
+            ApplicationManager.getApplication().invokeLater(
+                    () -> ProjectUtil.openOrImport(item.projectPath(), null, Boolean.FALSE));
         }
         return Boolean.TRUE;
     }


### PR DESCRIPTION
- Search Everywhere 选中回调在写意图读锁上下文（EDT + write-intent read）执行，同步 openOrImport 就地起模态进度，新项目打开所需写锁与持有的写意图读互等死锁
- 改为投递 EDT 队列尾部脱离锁上下文后打开