### PR TITLE
feat: 状态栏 JSON 路径面包屑与语法错误标注，发布 0.19.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,11 @@ intellijPlatform {
         version = project.version.toString()
         // sinceBuild 自 IGP 2.14 起默认取目标平台 major build（2026.2 → 262），无需显式声明
         changeNotes = """
+            <b>0.19.5</b>
+            <ul>
+                <li>状态栏 JSON 路径面包屑：光标在 JSON 文本中移动实时显示 JsonPath（穿透嵌套对象与数组索引），点击复制到剪贴板并弹通知。</li>
+                <li>JSON 语法错误内联标注：非法 JSON 红波浪线定位（基于 fastjson2 真实异常行列提取）。</li>
+            </ul>
             <b>0.19.2</b>
             <ul>
                 <li>修复 AnyParser 正斜杠路径被 Base64 正则误匹配（如 /api/data），增加首字符 '/' 排除。</li>

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 // 统一版本表：插件版本、目标平台、Java 基线与第三方依赖版本在此集中维护
 gradle.ext.versions = [
         // 插件版本：发布新版本时递增，并同步更新 build.gradle 中的 changeNotes
-        ver         : "0.19.2",
+        ver         : "0.19.5",
         // 目标 IntelliJ 平台版本：sinceBuild 自 IGP 2.14 起默认取平台 major build（2026.2 → 262），无需显式声明
         idea        : "2026.2",
         // Java 语言基线：toolchain 与 options.release 共用

--- a/src/main/java/com/acme/prism/ui/error/JsonErrorParser.java
+++ b/src/main/java/com/acme/prism/ui/error/JsonErrorParser.java
@@ -1,0 +1,66 @@
+package com.acme.prism.ui.error;
+
+import cn.hutool.core.lang.Opt;
+import cn.hutool.core.util.StrUtil;
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONException;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * JSON 语法错误定位工具，从 fastjson2 异常消息中提取行号和列号。
+ *
+ * @author 拒绝者
+ * @date 2026-07-29
+ */
+public class JsonErrorParser {
+
+    private static final Pattern LINE_COL_PATTERN = Pattern.compile("line (\\d+), column (\\d+)");
+    /** 跳过标注的 JSON 文本最大长度（字节），防止大文件解析阻塞标注线程 */
+    private static final int MAX_LENGTH = 500 * 1024;
+
+    /**
+     * 错误位置。
+     *
+     * @param line    行号（1-based）
+     * @param column  列号（1-based）
+     * @param message 错误描述
+     */
+    public record ErrorPosition(int line, int column, String message) {
+    }
+
+    /**
+     * 尝试解析 JSON 文本，返回首个语法错误的位置。
+     *
+     * @param json JSON 文本
+     * @return 错误位置；合法 JSON 或空文本返回 {@code null}
+     */
+    public static ErrorPosition parseError(final String json) {
+        if (StrUtil.isEmpty(json) || json.length() > MAX_LENGTH) {
+            return null;
+        }
+        try {
+            JSON.parse(json);
+            return null;
+        } catch (final JSONException e) {
+            return extractPosition(e.getMessage());
+        } catch (final Exception ignored) {
+            return null;
+        }
+    }
+
+    /**
+     * 从异常消息中提取行列信息。
+     */
+    static ErrorPosition extractPosition(final String message) {
+        return Opt.ofBlankAble(message)
+                .map(LINE_COL_PATTERN::matcher)
+                .filter(Matcher::find)
+                .map(m -> new ErrorPosition(
+                        Integer.parseInt(m.group(1)),
+                        Integer.parseInt(m.group(2)),
+                        message))
+                .orElse(null);
+    }
+}

--- a/src/main/java/com/acme/prism/ui/error/JsonSyntaxErrorAnnotator.java
+++ b/src/main/java/com/acme/prism/ui/error/JsonSyntaxErrorAnnotator.java
@@ -1,0 +1,63 @@
+package com.acme.prism.ui.error;
+
+import com.intellij.lang.annotation.AnnotationHolder;
+import com.intellij.lang.annotation.Annotator;
+import com.intellij.lang.annotation.HighlightSeverity;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.PsiDocumentManager;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * JSON 语法错误标注器。
+ *
+ * @author 拒绝者
+ * @date 2026-07-29
+ */
+public class JsonSyntaxErrorAnnotator implements Annotator {
+
+    @Override
+    public void annotate(@NotNull final PsiElement element, @NotNull final AnnotationHolder holder) {
+        final PsiFile file = element.getContainingFile();
+        if (file == null || element != file) {
+            return;
+        }
+        final Document doc = PsiDocumentManager.getInstance(file.getProject()).getDocument(file);
+        if (doc == null || !"json".equalsIgnoreCase(file.getFileType().getDefaultExtension())) {
+            return;
+        }
+        final JsonErrorParser.ErrorPosition error = JsonErrorParser.parseError(doc.getText());
+        if (error == null) {
+            return;
+        }
+        final int offset = logicalPositionToOffset(doc, error.line(), error.column());
+        final TextRange range = calculateErrorRange(doc.getText(), offset);
+        holder.newAnnotation(HighlightSeverity.ERROR, error.message())
+                .range(range)
+                .create();
+    }
+
+    private static int logicalPositionToOffset(final Document document, final int line, final int column) {
+        final int lineIndex = Math.max(0, Math.min(line - 1, document.getLineCount() - 1));
+        return Math.min(document.getLineStartOffset(lineIndex) + Math.max(0, column - 1), document.getTextLength());
+    }
+
+    private static TextRange calculateErrorRange(final String text, final int offset) {
+        if (offset < 0 || offset >= text.length()) {
+            return TextRange.EMPTY_RANGE;
+        }
+        int start = offset;
+        while (start > 0 && text.charAt(start - 1) != '\n') {
+            start--;
+        }
+        int end = offset + 2;
+        if (end < text.length()) {
+            while (end < text.length() && text.charAt(end) != '\n') {
+                end++;
+            }
+        }
+        return new TextRange(start, Math.min(end, text.length()));
+    }
+}

--- a/src/main/java/com/acme/prism/ui/statusbar/JsonPathStatusBarWidget.java
+++ b/src/main/java/com/acme/prism/ui/statusbar/JsonPathStatusBarWidget.java
@@ -1,0 +1,327 @@
+package com.acme.prism.ui.statusbar;
+
+import cn.hutool.core.util.StrUtil;
+import com.acme.prism.common.Clipboard;
+import com.acme.prism.core.notice.Notifier;
+import com.alibaba.fastjson2.JSON;
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.editor.event.CaretEvent;
+import com.intellij.openapi.editor.event.CaretListener;
+import com.intellij.openapi.fileEditor.FileDocumentManager;
+import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.fileEditor.FileEditorManagerEvent;
+import com.intellij.openapi.fileEditor.FileEditorManagerListener;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Disposer;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.openapi.wm.CustomStatusBarWidget;
+import com.intellij.openapi.wm.StatusBar;
+import com.intellij.openapi.wm.StatusBarWidget;
+import com.intellij.util.ui.UIUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.ResourceBundle;
+
+/**
+ * 状态栏 JSON 路径显示部件：实时显示光标所在 JsonPath，点击复制到剪贴板。
+ *
+ * @author 拒绝者
+ * @date 2026-07-29
+ */
+public class JsonPathStatusBarWidget implements CustomStatusBarWidget, CaretListener {
+
+    /** JSON 文件扩展名（小写） */
+    private static final String JSON_EXTENSION = "json";
+    /** 无有效路径时的占位显示 */
+    private static final String EMPTY_PATH = "Prism";
+    /** 路径解析内容缓存上限（字符），超过不缓存，避免大文件占用内存 */
+    private static final int CACHE_MAX_CHARS = 500 * 1024;
+
+    private static final ResourceBundle BUNDLE = ResourceBundle.getBundle("messages.PrismBundle");
+
+    /**
+     * 单条目区间缓存：同一时刻只有一个活动编辑器，内容不变时复用区间表，避免每次光标移动全量重扫。
+     * volatile 保证跨线程可见性（光标事件在 EDT，读取在 getText 也可能在 EDT，双保险）。
+     */
+    private static volatile String cachedText;
+    private static volatile List<NodeRange> cachedRanges;
+
+    private final Disposable disposable = Disposer.newDisposable("Prism.JsonPathWidget");
+    private JLabel label;
+    private Project project;
+    private StatusBar statusBar;
+    private Editor trackedEditor;
+
+    @Override
+    public @NotNull String ID() {
+        return "Prism.JsonPath";
+    }
+
+    @Override
+    public @Nullable WidgetPresentation getPresentation() {
+        return null;
+    }
+
+    @Override
+    public JComponent getComponent() {
+        if (Objects.isNull(label)) {
+            label = new JLabel(EMPTY_PATH);
+            label.setForeground(UIUtil.getLabelForeground());
+            label.setFont(UIUtil.getLabelFont());
+            label.setToolTipText(BUNDLE.getString("json.path.tooltip"));
+            // 点击复制当前路径到剪贴板
+            label.addMouseListener(new MouseAdapter() {
+                @Override
+                public void mouseClicked(final MouseEvent e) {
+                    final String current = label.getText();
+                    if (StrUtil.isEmpty(current) || EMPTY_PATH.equals(current)) {
+                        return;
+                    }
+                    Clipboard.copy(current);
+                    Notifier.notifyInfo(BUNDLE.getString("json.path.copied") + current, project);
+                }
+            });
+        }
+        return label;
+    }
+
+    @Override
+    public void install(@NotNull final StatusBar bar) {
+        this.statusBar = bar;
+        this.project = bar.getProject();
+        if (Objects.nonNull(project)) {
+            // 订阅编辑器切换，切换时重新绑定 caret 监听（避免全局 addCaretListener 的 deprecated API）
+            project.getMessageBus().connect(disposable)
+                    .subscribe(FileEditorManagerListener.FILE_EDITOR_MANAGER, new FileEditorManagerListener() {
+                        @Override
+                        public void selectionChanged(@NotNull final FileEditorManagerEvent event) {
+                            bindEditor(FileEditorManager.getInstance(project).getSelectedTextEditor());
+                        }
+                    });
+            bindEditor(FileEditorManager.getInstance(project).getSelectedTextEditor());
+        }
+    }
+
+    @Override
+    public void dispose() {
+        unbindEditor();
+        Disposer.dispose(disposable);
+    }
+
+    private void bindEditor(final Editor editor) {
+        unbindEditor();
+        if (Objects.nonNull(editor)) {
+            editor.getCaretModel().addCaretListener(this);
+            trackedEditor = editor;
+        }
+        refresh(editor);
+    }
+
+    private void unbindEditor() {
+        if (Objects.nonNull(trackedEditor)) {
+            trackedEditor.getCaretModel().removeCaretListener(this);
+            trackedEditor = null;
+        }
+    }
+
+    @Override
+    public void caretPositionChanged(@NotNull final CaretEvent event) {
+        refresh(event.getEditor());
+    }
+
+    private void refresh(final Editor editor) {
+        if (Objects.isNull(label) || Objects.isNull(project) || Objects.isNull(editor)) {
+            return;
+        }
+        final VirtualFile file = FileDocumentManager.getInstance().getFile(editor.getDocument());
+        if (Objects.isNull(file) || !JSON_EXTENSION.equalsIgnoreCase(file.getExtension())) {
+            label.setText(EMPTY_PATH);
+            return;
+        }
+        final String text = editor.getDocument().getText();
+        if (text.isEmpty()) {
+            label.setText(EMPTY_PATH);
+            return;
+        }
+        final String path = resolveJsonPath(text, editor.getCaretModel().getOffset());
+        label.setText(Objects.isNull(path) || path.isEmpty() ? EMPTY_PATH : path);
+    }
+
+    /**
+     * 从文本和光标位置解析 JSON 路径。
+     *
+     * <p>算法：解析 JSON 树校验合法性后，用括号匹配扫描原文，为每个键/数组元素构建
+     * [start, end) 文本区间与路径映射，找到包含光标 offset 的最深（最短）区间。
+     *
+     * <p>缓存：文本不变时复用上次构建的区间表，避免光标频繁移动导致重复全量扫描。
+     */
+    static String resolveJsonPath(final String text, final int offset) {
+        if (offset <= 0 || offset > text.length()) {
+            return "";
+        }
+        try {
+            JSON.parse(text);
+        } catch (final Exception ignored) {
+            return "";
+        }
+        // 缓存命中：文本未变且未超上限，直接复用区间表
+        List<NodeRange> ranges = text.length() <= CACHE_MAX_CHARS ? cachedRanges : null;
+        if (Objects.isNull(ranges) || !text.equals(cachedText)) {
+            ranges = new ArrayList<>();
+            buildRanges(text, 0, text.length(), "$", ranges);
+            if (text.length() <= CACHE_MAX_CHARS) {
+                cachedText = text;
+                cachedRanges = ranges;
+            }
+        }
+        NodeRange best = null;
+        for (final NodeRange range : ranges) {
+            if (range.start <= offset && offset < range.end
+                    && (Objects.isNull(best) || range.length() < best.length())) {
+                best = range;
+            }
+        }
+        return Objects.isNull(best) ? "" : best.path;
+    }
+
+    /**
+     * 节点文本区间：start 起、end 止，path 为完整 JsonPath。
+     */
+    private record NodeRange(int start, int end, String path) {
+        int length() {
+            return this.end - this.start;
+        }
+    }
+
+    private static void buildRanges(final String text, final int start, final int end,
+                                    final String path, final List<NodeRange> ranges) {
+        int pos = start;
+        while (pos < end) {
+            final char c = text.charAt(pos);
+            if (c == '{') {
+                final int matched = findMatching(text, pos, '}');
+                if (matched < 0) {
+                    return;
+                }
+                ranges.add(new NodeRange(pos, matched + 1, path));
+                buildRanges(text, pos + 1, matched, path, ranges);
+                pos = matched + 1;
+            } else if (c == '[') {
+                final int matched = findMatching(text, pos, ']');
+                if (matched < 0) {
+                    return;
+                }
+                ranges.add(new NodeRange(pos, matched + 1, path));
+                // 逐个数组元素处理并附加 [index]
+                int elemPos = pos + 1;
+                int idx = 0;
+                while (elemPos < matched) {
+                    while (elemPos < matched
+                            && (Character.isWhitespace(text.charAt(elemPos)) || text.charAt(elemPos) == ',')) {
+                        elemPos++;
+                    }
+                    if (elemPos >= matched) {
+                        break;
+                    }
+                    final char elemChar = text.charAt(elemPos);
+                    if (elemChar == '{' || elemChar == '[') {
+                        final int elemMatch = findMatching(text, elemPos, elemChar == '{' ? '}' : ']');
+                        if (elemMatch < 0) {
+                            return;
+                        }
+                        ranges.add(new NodeRange(elemPos, elemMatch + 1, path + "[" + idx + "]"));
+                        buildRanges(text, elemPos, elemMatch, path + "[" + idx + "]", ranges);
+                        elemPos = elemMatch + 1;
+                    } else {
+                        final int elemEnd = findValueEnd(text, elemPos, matched);
+                        elemPos = Math.max(elemEnd, elemPos + 1);
+                    }
+                    idx++;
+                }
+                pos = matched + 1;
+            } else if (c == '"') {
+                final int keyEnd = text.indexOf('"', pos + 1);
+                if (keyEnd < 0) {
+                    return;
+                }
+                final String key = text.substring(pos + 1, keyEnd);
+                // 跳过 ":" 定位值起点
+                int valueStart = keyEnd + 1;
+                while (valueStart < end && (text.charAt(valueStart) == ':' || Character.isWhitespace(text.charAt(valueStart)))) {
+                    valueStart++;
+                }
+                if (valueStart >= end) {
+                    return;
+                }
+                // 确定值的结束位置
+                final int valueEnd = findValueEnd(text, valueStart, end);
+                ranges.add(new NodeRange(pos, valueEnd, path + "." + key));
+                // 值内部是对象/数组时递归（路径带 key）
+                if (text.charAt(valueStart) == '{' || text.charAt(valueStart) == '[') {
+                    buildRanges(text, valueStart, valueEnd - 1, path + "." + key, ranges);
+                }
+                pos = valueEnd;
+            } else {
+                pos++;
+            }
+        }
+    }
+
+    /**
+     * 从 start 位置开始查找匹配的闭合括号（处理嵌套与字符串）。
+     */
+    private static int findMatching(final String text, final int start, final char close) {
+        final char open = close == '}' ? '{' : '[';
+        int depth = 0;
+        boolean inString = false;
+        for (int i = start; i < text.length(); i++) {
+            final char c = text.charAt(i);
+            if (c == '"') {
+                inString = !inString;
+            } else if (!inString) {
+                if (c == open) {
+                    depth++;
+                } else if (c == close) {
+                    depth--;
+                    if (depth == 0) {
+                        return i;
+                    }
+                }
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * 查找值（可能是对象/数组/标量）的结束位置。
+     */
+    private static int findValueEnd(final String text, final int valueStart, final int end) {
+        final char first = text.charAt(valueStart);
+        if (first == '{' || first == '[') {
+            final int matched = findMatching(text, valueStart, first == '{' ? '}' : ']');
+            return matched < 0 ? end : matched + 1;
+        }
+        if (first == '"') {
+            final int quoteEnd = text.indexOf('"', valueStart + 1);
+            return quoteEnd < 0 ? end : quoteEnd + 1;
+        }
+        // 标量：到下一个逗号或闭合括号或空白
+        int pos = valueStart;
+        while (pos < end) {
+            final char c = text.charAt(pos);
+            if (c == ',' || c == '}' || c == ']' || Character.isWhitespace(c)) {
+                break;
+            }
+            pos++;
+        }
+        return pos;
+    }
+}

--- a/src/main/java/com/acme/prism/ui/statusbar/JsonPathStatusBarWidgetFactory.java
+++ b/src/main/java/com/acme/prism/ui/statusbar/JsonPathStatusBarWidgetFactory.java
@@ -1,0 +1,46 @@
+package com.acme.prism.ui.statusbar;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.wm.StatusBar;
+import com.intellij.openapi.wm.StatusBarWidget;
+import com.intellij.openapi.wm.StatusBarWidgetFactory;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * 状态栏 JSON 路径部件工厂。
+ *
+ * @author 拒绝者
+ * @date 2026-07-29
+ */
+public class JsonPathStatusBarWidgetFactory implements StatusBarWidgetFactory {
+
+    @Override
+    public @NotNull String getId() {
+        return "Prism.JsonPath";
+    }
+
+    @Override
+    public @NotNull String getDisplayName() {
+        return "JSON Path";
+    }
+
+    @Override
+    public boolean isAvailable(@NotNull final Project project) {
+        return true;
+    }
+
+    @Override
+    public @NotNull StatusBarWidget createWidget(@NotNull final Project project) {
+        return new JsonPathStatusBarWidget();
+    }
+
+    @Override
+    public void disposeWidget(@NotNull final StatusBarWidget widget) {
+        widget.dispose();
+    }
+
+    @Override
+    public boolean canBeEnabledOn(@NotNull final StatusBar statusBar) {
+        return true;
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -109,5 +109,10 @@
         <additionalTextAttributes scheme="Darcula" file="colorSchemes/RainbowBracketPairDefault.xml"/>
         <!-- 彩虹括号配对高亮：颜色设置页 -->
         <colorSettingsPage implementation="com.acme.prism.core.rainbow.RainbowBracketPairColorSettingsPage"/>
+        <!-- 状态栏 JSON 路径面包屑 -->
+        <statusBarWidgetFactory implementation="com.acme.prism.ui.statusbar.JsonPathStatusBarWidgetFactory"
+                                id="Prism.JsonPath"/>
+        <!-- JSON 语法错误内联标注 -->
+        <annotator implementationClass="com.acme.prism.ui.error.JsonSyntaxErrorAnnotator"/>
     </extensions>
 </idea-plugin>

--- a/src/main/resources/messages/PrismBundle.properties
+++ b/src/main/resources/messages/PrismBundle.properties
@@ -98,3 +98,6 @@ rainbow.bracket.pair.color.page=Bracket Colors
 rainbow.bracket.pair.color.brace=Braces
 rainbow.bracket.pair.color.bracket=Brackets
 rainbow.bracket.pair.color.parenthesis=Parentheses
+json.error.syntax=JSON Syntax Error
+json.path.copied=JSON path copied: 
+json.path.tooltip=Click to copy JSON path

--- a/src/main/resources/messages/PrismBundle_zh_CN.properties
+++ b/src/main/resources/messages/PrismBundle_zh_CN.properties
@@ -98,3 +98,6 @@ rainbow.bracket.pair.color.page=括号配色
 rainbow.bracket.pair.color.brace=花括号
 rainbow.bracket.pair.color.bracket=方括号
 rainbow.bracket.pair.color.parenthesis=圆括号
+json.error.syntax=JSON 语法错误
+json.path.copied=JSON 路径已复制：
+json.path.tooltip=点击复制 JSON 路径

--- a/src/test/java/com/acme/prism/ui/error/JsonErrorParserTest.java
+++ b/src/test/java/com/acme/prism/ui/error/JsonErrorParserTest.java
@@ -1,0 +1,147 @@
+package com.acme.prism.ui.error;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * JsonErrorParser 单元测试：基于真实 fastjson2 异常消息验证行列提取。
+ *
+ * <p>测试数据来自对 {@code JSON.parse} 真实捕获的 JSONException 消息（2026-07-31 实测，
+ * fastjson2 2.0.62）。禁止使用编造的异常消息样本。
+ *
+ * @author 拒绝者
+ * @date 2026-07-29
+ */
+class JsonErrorParserTest {
+
+    // --------------- 提取行列（基于真实异常消息） ---------------
+
+    @Test
+    @DisplayName("正常：{bad 的真实异常消息可提取行列")
+    void extractFromRealUnquotedFieldError() {
+        // 实测：JSON.parse("{bad") => "not allow unquoted fieldName, offset 2, character b, line 1, column 2, fastjson-version 2.0.62 {bad"
+        final JsonErrorParser.ErrorPosition pos = JsonErrorParser.extractPosition(
+                "not allow unquoted fieldName, offset 2, character b, line 1, column 2, fastjson-version 2.0.62 {bad");
+        assertAll(
+                () -> assertNotNull(pos, "应提取到位置信息"),
+                () -> assertEquals(1, pos.line(), "行号应为 1"),
+                () -> assertEquals(2, pos.column(), "列号应为 2")
+        );
+    }
+
+    @Test
+    @DisplayName("正常：[,] 的真实异常消息可提取行列")
+    void extractFromRealTrailingCommaError() {
+        // 实测：JSON.parse("[,]") => "offset 2, character ,, line 1, column 2, fastjson-version 2.0.62 [,]"
+        final JsonErrorParser.ErrorPosition pos = JsonErrorParser.extractPosition(
+                "offset 2, character ,, line 1, column 2, fastjson-version 2.0.62 [,]");
+        assertAll(
+                () -> assertNotNull(pos),
+                () -> assertEquals(1, pos.line()),
+                () -> assertEquals(2, pos.column())
+        );
+    }
+
+    @Test
+    @DisplayName("正常：[\"unclosed 的真实异常消息可提取行列")
+    void extractFromRealUnclosedStringError() {
+        // 实测：JSON.parse("[\"unclosed") => "invalid escape character EOI, offset 2, character \", line 1, column 2, fastjson-version 2.0.62 [\"unclosed"
+        final JsonErrorParser.ErrorPosition pos = JsonErrorParser.extractPosition(
+                "invalid escape character EOI, offset 2, character \", line 1, column 2, fastjson-version 2.0.62 [\"unclosed");
+        assertNotNull(pos, "应提取到位置信息");
+        assertEquals(2, pos.column());
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"no line info here", "some error without numbers",
+            "syntax error, offset 5, char \""})
+    @DisplayName("边界：无 line/column 信息的真实异常消息返回 null")
+    void returnsNullForUnparseableMessage(final String message) {
+        // "syntax error, offset 5, char \"" 是 JSON.parse("{\"a\" 1}") 的真实异常消息，无行列信息
+        assertNull(JsonErrorParser.extractPosition(message), "无行列信息应返回 null");
+    }
+
+    // --------------- 完整解析（真实输入） ---------------
+
+    @Test
+    @DisplayName("正常：非法 JSON 返回错误位置")
+    void parseErrorReturnsPositionForInvalidJson() {
+        final JsonErrorParser.ErrorPosition pos = JsonErrorParser.parseError("{bad");
+        assertNotNull(pos, "非法 JSON 应返回错误位置");
+        assertTrue(pos.message().contains("line"), "消息应包含行列信息");
+    }
+
+    @Test
+    @DisplayName("正常：逗号多余的数组 [,] 返回错误位置")
+    void parseErrorForTrailingComma() {
+        final JsonErrorParser.ErrorPosition pos = JsonErrorParser.parseError("[,]");
+        assertNotNull(pos, "[,] 应返回错误位置");
+        assertTrue(pos.line() >= 1, "行号应 >= 1");
+    }
+
+    @Test
+    @DisplayName("边界：异常消息无行列信息的非法 JSON 返回 null（无法定位）")
+    void parseErrorReturnsNullWhenPositionUnavailable() {
+        // 实测：JSON.parse("{\"a\" 1}") 的消息为 "syntax error, offset 5, char \""，无 line/column
+        final JsonErrorParser.ErrorPosition pos = JsonErrorParser.parseError("{\"a\" 1}");
+        assertNull(pos, "无法提取行列时应返回 null，标注器跳过该错误");
+    }
+
+    @Test
+    @DisplayName("边界：尾逗号 {a:1,} 是合法 JSON（fastjson2 容忍），返回 null")
+    void parseErrorAllowsTrailingComma() {
+        // 实测：JSON.parse("{\"a\": 1,}") 不抛异常（fastjson2 容忍尾逗号）
+        assertNull(JsonErrorParser.parseError("{\"a\": 1,}"), "尾逗号 JSON 不应报错");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "{\"a\":1}",
+            "[1,2,3]",
+            "true",
+            "\"hello\"",
+            "{\"nested\":{\"key\":\"value\"}}",
+            "[{\"id\":1},{\"id\":2}]"
+    })
+    @DisplayName("正常：合法 JSON 返回 null")
+    void parseErrorReturnsNullForValidJson(final String json) {
+        assertNull(JsonErrorParser.parseError(json), "合法 JSON 不应返回错误");
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @DisplayName("边界：null 与空串返回 null")
+    void parseErrorReturnsNullForBlank(final String json) {
+        assertNull(JsonErrorParser.parseError(json), "空白输入应返回 null");
+    }
+
+    // --------------- 测试数据真实性校验：探针断言与实测一致 ---------------
+
+    @ParameterizedTest
+    @ValueSource(strings = {"{bad", "[,]", "[\"unclosed", "{\"a\" 1}", "{\"a\": 1,}", "not json at all"})
+    @DisplayName("探针：真实 JSON.parse 行为与 parseError 结果一致")
+    void probeRealBehavior(final String input) {
+        boolean realThrows;
+        try {
+            JSON.parse(input);
+            realThrows = false;
+        } catch (final JSONException e) {
+            realThrows = true;
+        }
+        // 真实抛异常的输入，若消息含行列则 parseError 返回非 null；否则返回 null
+        if (!realThrows) {
+            assertNull(JsonErrorParser.parseError(input), input + " 不应报错");
+        } else {
+            // 无论能否定位，parseError 都不应抛异常（可能返回 null）
+            assertDoesNotThrow(() -> JsonErrorParser.parseError(input), input + " parseError 不应抛异常");
+        }
+    }
+}

--- a/src/test/java/com/acme/prism/ui/statusbar/JsonPathResolverTest.java
+++ b/src/test/java/com/acme/prism/ui/statusbar/JsonPathResolverTest.java
@@ -1,0 +1,89 @@
+package com.acme.prism.ui.statusbar;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * JSON 路径解析器单元测试：从文本和光标位置计算 JsonPath。
+ *
+ * @author 拒绝者
+ * @date 2026-07-29
+ */
+class JsonPathResolverTest {
+
+    @Test
+    @DisplayName("顶层：光标在键名内返回 $.key")
+    void topLevelKeyCursor() {
+        assertEquals("$.name", JsonPathStatusBarWidget.resolveJsonPath("{\"name\":\"test\"}", 2));
+    }
+
+    @Test
+    @DisplayName("顶层：光标在值内返回 $.key")
+    void topLevelValueCursor() {
+        assertEquals("$.name", JsonPathStatusBarWidget.resolveJsonPath("{\"name\":\"test\"}", 10));
+    }
+
+    @Test
+    @DisplayName("嵌套二层：光标在嵌套键处返回完整路径")
+    void nestedTwoLevelKeyCursor() {
+        assertEquals("$.a.b", JsonPathStatusBarWidget.resolveJsonPath("{\"a\":{\"b\":1}}", 8));
+    }
+
+    @Test
+    @DisplayName("数组：光标在数组元素对象内返回 $.key[index].subkey")
+    void arrayElementNestedKey() {
+        final String json = "{\"versions\":[{\"type\":\"release\"}]}";
+        // "type" 键名位置
+        assertEquals("$.versions[0].type", JsonPathStatusBarWidget.resolveJsonPath(json, 20));
+    }
+
+    @Test
+    @DisplayName("数组：光标在第二个数组元素内返回 $.key[1].subkey")
+    void secondArrayElementKey() {
+        final String json = "{\"versions\":[{\"type\":\"a\"},{\"type\":\"b\"}]}";
+        // 第二个元素的 "type" 键名内（offset 29 附近）
+        assertEquals("$.versions[1].type", JsonPathStatusBarWidget.resolveJsonPath(json, 29));
+    }
+
+    @Test
+    @DisplayName("缓存：文本不变时二次调用返回一致结果（命中缓存）")
+    void cacheHitReturnsConsistentResult() {
+        final String json = "{\"a\":{\"b\":1}}";
+        final String first = JsonPathStatusBarWidget.resolveJsonPath(json, 8);
+        final String second = JsonPathStatusBarWidget.resolveJsonPath(json, 8);
+        assertEquals(first, second, "相同文本相同 offset 应返回一致路径");
+        assertFalse(first.isEmpty(), "路径不应为空");
+    }
+
+    @Test
+    @DisplayName("缓存：文本变化后返回新结果（缓存失效）")
+    void cacheInvalidatesOnTextChange() {
+        final String jsonA = "{\"a\":{\"b\":1}}";
+        final String jsonB = "{\"x\":{\"y\":2}}";
+        final String pathA = JsonPathStatusBarWidget.resolveJsonPath(jsonA, 8);
+        final String pathB = JsonPathStatusBarWidget.resolveJsonPath(jsonB, 8);
+        assertEquals("$.a.b", pathA, "文本 A 应解析出 $.a.b");
+        assertEquals("$.x.y", pathB, "文本 B 应解析出 $.x.y（缓存已失效）");
+    }
+
+    @Test
+    @DisplayName("边界：offset 为 0 返回空串")
+    void offsetZeroReturnsRoot() {
+        assertEquals("", JsonPathStatusBarWidget.resolveJsonPath("{\"a\":1}", 0));
+    }
+
+    @Test
+    @DisplayName("边界：空字符串返回空串")
+    void emptyStringReturnsRoot() {
+        assertEquals("", JsonPathStatusBarWidget.resolveJsonPath("", 0));
+    }
+
+    @Test
+    @DisplayName("边界：非法 JSON 返回 $（优雅降级不抛异常）")
+    void invalidJsonGracefulDegradation() {
+        assertDoesNotThrow(() -> JsonPathStatusBarWidget.resolveJsonPath("{bad", 3),
+                "非法 JSON 不应抛异常");
+    }
+}


### PR DESCRIPTION
- 状态栏 JSON 路径面包屑：光标移动实时显示 JsonPath（括号匹配区间扫描，穿透嵌套对象与数组索引），点击复制到剪贴板并气泡通知
- JSON 语法错误内联标注：fastjson2 真实异常消息提取行列，红波浪线定位；无行列信息或合法 JSON 不标注
- 性能：路径解析加单条目内容缓存（500KB 上限），光标移动不重复全量扫描
- 弃用 deprecated 的 addCaretListener，改用 FileEditorManagerListener + 每编辑器 caret 监听
- 测试：JsonErrorParserTest 基于真实 fastjson2 异常消息校准（{bad/[,]/["unclosed 可定位，{"a" 1} 无行列返回 null，尾逗号合法）；JsonPathResolverTest 覆盖嵌套/数组/缓存命中与失效