### PR TITLE
feat: JSON 编辑器折叠与视口记忆，发布 0.19.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,13 @@ intellijPlatform {
         version = project.version.toString()
         // sinceBuild 自 IGP 2.14 起默认取目标平台 major build（2026.2 → 262），无需显式声明
         changeNotes = """
+            <b>0.19.6</b>
+            <ul>
+                <li>JSON 编辑器折叠：多行 JSON 自动生成可折叠区间（对象/数组括号对，字符串内括号忽略）。</li>
+                <li>性能护栏：超过 1MB 的 JSON 跳过自动识别与树构建，避免大文件阻塞 UI。</li>
+                <li>编辑器视口记忆：滚动位置实时记录，页签切换与项目重开均还原；无记录时默认置顶。</li>
+                <li>树面板刷新修复：文档监听改为内容去重（替代失效的引用比较），历史回显主动加载。</li>
+            </ul>
             <b>0.19.5</b>
             <ul>
                 <li>状态栏 JSON 路径面包屑：光标在 JSON 文本中移动实时显示 JsonPath（穿透嵌套对象与数组索引），点击复制到剪贴板并弹通知。</li>

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 // 统一版本表：插件版本、目标平台、Java 基线与第三方依赖版本在此集中维护
 gradle.ext.versions = [
         // 插件版本：发布新版本时递增，并同步更新 build.gradle 中的 changeNotes
-        ver         : "0.19.5",
+        ver         : "0.19.6",
         // 目标 IntelliJ 平台版本：sinceBuild 自 IGP 2.14 起默认取平台 major build（2026.2 → 262），无需显式声明
         idea        : "2026.2",
         // Java 语言基线：toolchain 与 options.release 共用

--- a/src/main/java/com/acme/prism/core/editor/JsonFoldingCalculator.java
+++ b/src/main/java/com/acme/prism/core/editor/JsonFoldingCalculator.java
@@ -1,0 +1,124 @@
+package com.acme.prism.core.editor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * JSON 折叠区域计算器：扫描文本，找出跨行的对象/数组括号对。
+ *
+ * <p>纯逻辑类，不依赖 IntelliJ API，可单元测试。仅返回跨行区间
+ * （起始行与结束行不同），单行/压缩 JSON 不产生折叠区域。
+ *
+ * @author 拒绝者
+ * @date 2026-07-31
+ */
+public class JsonFoldingCalculator {
+
+    /**
+     * 折叠区域：startOffset 起、endOffset 止（含两端），placeholder 为折叠占位文本。
+     */
+    public record FoldRegion(int startOffset, int endOffset, String placeholder) {
+    }
+
+    /**
+     * 计算文本中可折叠的 JSON 括号对。
+     *
+     * @param text JSON 文本
+     * @return 跨行括号对的折叠区域列表；无折叠点时返回空列表
+     */
+    public static List<FoldRegion> calculate(final String text) {
+        final List<FoldRegion> regions = new ArrayList<>();
+        if (text == null || text.isEmpty()) {
+            return regions;
+        }
+        // 预计算每行起始 offset，用于 O(log n) 定位任意 offset 所在行
+        final int[] lineStarts = buildLineStarts(text);
+        scan(text, 0, text.length(), lineStarts, regions);
+        return regions;
+    }
+
+    private static int[] buildLineStarts(final String text) {
+        final List<Integer> starts = new ArrayList<>();
+        starts.add(0);
+        for (int i = 0; i < text.length(); i++) {
+            if (text.charAt(i) == '\n') {
+                starts.add(i + 1);
+            }
+        }
+        final int[] arr = new int[starts.size()];
+        for (int i = 0; i < starts.size(); i++) {
+            arr[i] = starts.get(i);
+        }
+        return arr;
+    }
+
+    private static void scan(final String text, final int start, final int end,
+                             final int[] lineStarts, final List<FoldRegion> regions) {
+        int pos = start;
+        boolean inString = false;
+        while (pos < end) {
+            final char c = text.charAt(pos);
+            if (c == '"') {
+                inString = !inString;
+                pos++;
+                continue;
+            }
+            if (inString) {
+                pos++;
+                continue;
+            }
+            if (c == '{' || c == '[') {
+                final char close = c == '{' ? '}' : ']';
+                final int matched = findMatching(text, pos, close);
+                if (matched < 0) {
+                    return;
+                }
+                // 仅跨行区间可折叠
+                if (lineOf(lineStarts, pos) < lineOf(lineStarts, matched)) {
+                    regions.add(new FoldRegion(pos, matched + 1, c == '{' ? "{...}" : "[...]"));
+                }
+                // 递归处理内部
+                scan(text, pos + 1, matched, lineStarts, regions);
+                pos = matched + 1;
+            } else {
+                pos++;
+            }
+        }
+    }
+
+    private static int findMatching(final String text, final int start, final char close) {
+        final char open = close == '}' ? '{' : '[';
+        int depth = 0;
+        boolean inString = false;
+        for (int i = start; i < text.length(); i++) {
+            final char c = text.charAt(i);
+            if (c == '"') {
+                inString = !inString;
+            } else if (!inString) {
+                if (c == open) {
+                    depth++;
+                } else if (c == close) {
+                    depth--;
+                    if (depth == 0) {
+                        return i;
+                    }
+                }
+            }
+        }
+        return -1;
+    }
+
+    private static int lineOf(final int[] lineStarts, final int offset) {
+        int low = 0;
+        int high = lineStarts.length - 1;
+        while (low <= high) {
+            final int mid = (low + high) >>> 1;
+            if (lineStarts[mid] <= offset) {
+                low = mid + 1;
+            } else {
+                high = mid - 1;
+            }
+        }
+        return high;
+    }
+}

--- a/src/main/java/com/acme/prism/core/editor/record/EditorState.java
+++ b/src/main/java/com/acme/prism/core/editor/record/EditorState.java
@@ -14,7 +14,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * @author 拒绝者
  * @date 2025-11-04
  */
-public record EditorState(Integer editorId, String content) {
+public record EditorState(Integer editorId, String content, Integer scrollOffset, Integer caretOffset) {
     /**
      * Base64 编码器
      */
@@ -41,6 +41,27 @@ public record EditorState(Integer editorId, String content) {
     public static final Set<String> SAVED_MARK = ConcurrentHashMap.newKeySet();
 
     /**
+     * 兼容构造：无滚动与光标位置（旧数据或首次创建），恢复时默认置顶。
+     *
+     * @param editorId 编辑器 ID
+     * @param content  内容
+     */
+    public EditorState(final Integer editorId, final String content) {
+        this(editorId, content, null, null);
+    }
+
+    /**
+     * 兼容构造：带滚动位置（历史格式）。
+     *
+     * @param editorId     编辑器 ID
+     * @param content      内容
+     * @param scrollOffset 滚动位置
+     */
+    public EditorState(final Integer editorId, final String content, final Integer scrollOffset) {
+        this(editorId, content, scrollOffset, null);
+    }
+
+    /**
      * 编码
      * @param stateList 列表
      * @return {@link String }
@@ -56,10 +77,14 @@ public record EditorState(Integer editorId, String content) {
             if (!first) {
                 builder.append(SEP_OUTSIDE);
             }
-            // content 为 null 时按空串处理，避免编码器 NPE
+            // content 为 null 时按空串处理，避免编码器 NPE；scrollOffset/caretOffset 为 null 时写空段
             builder.append(state.editorId)
                     .append(SEP_INTERNAL)
-                    .append(BASE64_ENCODER.encodeToString(StrUtil.bytes(Objects.requireNonNullElse(state.content, ""), StandardCharsets.UTF_8)));
+                    .append(BASE64_ENCODER.encodeToString(StrUtil.bytes(Objects.requireNonNullElse(state.content, ""), StandardCharsets.UTF_8)))
+                    .append(SEP_INTERNAL)
+                    .append(Objects.isNull(state.scrollOffset) ? "" : state.scrollOffset)
+                    .append(SEP_INTERNAL)
+                    .append(Objects.isNull(state.caretOffset) ? "" : state.caretOffset);
             first = false;
         }
         return builder.toString();
@@ -78,12 +103,15 @@ public record EditorState(Integer editorId, String content) {
                 continue;
             }
             final String[] parts = entry.split(SEP_INTERNAL, -1);
-            if (ArrayUtil.isEmpty(parts) || parts.length != 2) {
+            // 兼容旧数据：历史版本仅 2 段（id, content），滚动/光标位置为 null
+            if (ArrayUtil.isEmpty(parts) || parts.length < 2) {
                 continue;
             }
             states.add(new EditorState(
                     Convert.toInt(parts[0]),
-                    StrUtil.utf8Str(BASE64_DECODER.decode(parts[1]))
+                    StrUtil.utf8Str(BASE64_DECODER.decode(parts[1])),
+                    parts.length >= 3 ? Convert.toInt(parts[2]) : null,
+                    parts.length >= 4 ? Convert.toInt(parts[3]) : null
             ));
         }
         return states;

--- a/src/main/java/com/acme/prism/ui/MainToolWindowFactory.java
+++ b/src/main/java/com/acme/prism/ui/MainToolWindowFactory.java
@@ -117,9 +117,20 @@ public class MainToolWindowFactory implements ToolWindowFactory, DumbAware {
                                             .flatMap(number ->
                                                     Opt.ofNullable(JsonEditorPushProvider.deepFindEditor(contents[number].getComponent()))
                                                             .filter(Objects::nonNull)
-                                                            .map(field ->
-                                                                    Stream.of(new EditorState(Convert.toInt(contents[number].getTabName()), field.getText()))
-                                                            ).orElseGet(Stream::empty)
+                                                            .map(field -> {
+                                                                // 优先读编辑器实时滚动偏移；编辑器已释放（IDE 关闭流程）则回退到 factory 记录值
+                                                                final Integer scroll = Opt.ofNullable(field.getEditor())
+                                                                        .map(editor -> editor.getScrollingModel().getVerticalScrollOffset())
+                                                                        .orElseGet(() -> {
+                                                                            final Object f = field.getClientProperty(CUSTOMIZE_FACTORY_KEY);
+                                                                            return f instanceof final CustomizeEditorFactory cf ? cf.getCurrentScrollOffset() : null;
+                                                                        });
+                                                                return Stream.of(new EditorState(
+                                                                        Convert.toInt(contents[number].getTabName()),
+                                                                        field.getText(),
+                                                                        scroll
+                                                                ));
+                                                            }).orElseGet(Stream::empty)
                                             ).toList()
                             )
                     );
@@ -164,8 +175,12 @@ public class MainToolWindowFactory implements ToolWindowFactory, DumbAware {
         Disposer.register(ProjectDisposableService.getInstance(project), tabDisposable);
         // 增加页签号数
         final int number = Opt.ofNullable(restore).map(EditorState::editorId).peek(tabCounter::set).orElseGet(tabCounter::incrementAndGet);
-        // 创建页签内容面板
-        final JPanel contentPanel = this.createWindowContent(project, number, Opt.ofNullable(restore).map(EditorState::content).orElse(null), tabDisposable);
+        // 创建页签内容面板（携带保存的视口滚动偏移；无保存值时默认置顶）
+        final JPanel contentPanel = this.createWindowContent(
+                project, number,
+                Opt.ofNullable(restore).map(EditorState::content).orElse(null),
+                Opt.ofNullable(restore).map(EditorState::scrollOffset).orElse(null),
+                tabDisposable);
         // 创建页签内容
         final Content content = ContentFactory.getInstance().createContent(contentPanel, String.valueOf(number), Boolean.FALSE);
         // 可关闭设置
@@ -217,18 +232,28 @@ public class MainToolWindowFactory implements ToolWindowFactory, DumbAware {
     }
 
     /**
+     * 页签编辑器与其 CustomizeEditorFactory 的关联键（EditorTextField client property）
+     */
+    private static final String CUSTOMIZE_FACTORY_KEY = "prism.json.factory";
+
+    /**
      * 创建窗口内容
      *
-     * @param project 项目
-     * @param number  页签号数
-     * @param content 内容
+     * @param project      项目
+     * @param number       页签号数
+     * @param content      内容
+     * @param scrollOffset 保存的视口滚动偏移（项目重开还原），null 表示置顶
      * @return {@link JPanel }
      */
-    private JPanel createWindowContent(@NotNull final Project project, final int number, final String content, final Disposable tabDisposable) {
+    private JPanel createWindowContent(@NotNull final Project project, final int number, final String content,
+                                       final Integer scrollOffset, final Disposable tabDisposable) {
         // 窗口工具
         final JPanel toolWindow = new JPanel(new BorderLayout(0, 0));
-        // 创建JSON编辑器
-        final EditorTextField editor = new CustomizeEditorFactory(SupportedLanguages.JSON, "Dummy_%d.json".formatted(number)).create(project);
+        // 创建JSON编辑器（初始视口偏移：有保存值则还原，无则置顶；页签切换由 VisibleAreaListener 实时记录）
+        final CustomizeEditorFactory factory = new CustomizeEditorFactory(SupportedLanguages.JSON, "Dummy_%d.json".formatted(number), scrollOffset);
+        final EditorTextField editor = factory.create(project);
+        // 关联 factory：IDE 关闭保存时若 editor 已释放，从 factory 读取实时滚动偏移兜底
+        editor.putClientProperty(CUSTOMIZE_FACTORY_KEY, factory);
         // 填充内容
         Opt.ofBlankAble(content).ifPresent(editor::setText);
         // 等待编辑器初始化后，挂载面板功能

--- a/src/main/java/com/acme/prism/ui/editor/CustomizeEditorFactory.java
+++ b/src/main/java/com/acme/prism/ui/editor/CustomizeEditorFactory.java
@@ -1,31 +1,134 @@
 package com.acme.prism.ui.editor;
 
 import com.acme.prism.common.enums.SupportedLanguages;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.editor.ScrollingModel;
+import com.intellij.openapi.editor.event.VisibleAreaEvent;
+import com.intellij.openapi.editor.event.VisibleAreaListener;
+import com.intellij.openapi.editor.ex.EditorEx;
+import com.intellij.openapi.fileTypes.LanguageFileType;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiDocumentManager;
 import com.intellij.psi.PsiFileFactory;
 import com.intellij.ui.EditorTextField;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Objects;
 
 /**
- * 编辑器工厂
- * @param fileName 文件名
- * @param language 编辑器语言
+ * 编辑器工厂。
+ *
+ * <p>视口滚动偏移（{@code initialScrollOffset}）为可变字段，由 ScrollingListener 实时记录，
+ * 覆盖滑动条/代码地图/滚轮等所有滚动方式。编辑器组件创建与页签切换重建时，
+ * 滚动视口到目标位置：无记录时置顶（0），有记录时还原之前视口位置。
+ * 滚动需布局完成后生效，故立即执行 + 延迟兜底（轻微动画，平台限制）。
+ *
  * @author 拒绝者
  * @date 2025-04-22
  */
-public record CustomizeEditorFactory(SupportedLanguages language, String fileName) implements Editor {
+public final class CustomizeEditorFactory {
+
+    /** 忽略创建初期 IntelliJ 初始化滚动的时间窗（毫秒），避免把自动滚到底部误记为用户位置 */
+    private static final int INIT_SCROLL_IGNORE_MS = 500;
+
+    private final SupportedLanguages language;
+    private final String fileName;
+    /** 最近一次视口滚动偏移（ScrollingListener 实时记录），null 表示置顶 */
+    private volatile Integer initialScrollOffset;
+
     /**
      * 编辑器工厂
+     *
      * @param language 语言
      * @param fileName 文件名
      */
-    public CustomizeEditorFactory {
+    public CustomizeEditorFactory(final SupportedLanguages language, final String fileName) {
+        this(language, fileName, null);
     }
 
-    @Override
+    /**
+     * 编辑器工厂（携带保存的视口滚动偏移）。
+     *
+     * @param language        语言
+     * @param fileName        文件名
+     * @param initialScrollOffset 初始视口滚动偏移（项目重开还原），null 表示置顶
+     */
+    public CustomizeEditorFactory(final SupportedLanguages language, final String fileName,
+                                  @Nullable final Integer initialScrollOffset) {
+        this.language = language;
+        this.fileName = fileName;
+        this.initialScrollOffset = initialScrollOffset;
+    }
+
+    /**
+     * 读取当前记录的视口滚动偏移（编辑器释放后由 MainToolWindowFactory 保存时兜底读取）。
+     *
+     * @return 最近一次视口滚动偏移，null 表示置顶
+     */
+    @Nullable
+    public Integer getCurrentScrollOffset() {
+        return this.initialScrollOffset;
+    }
+
+    /**
+     * 创建编辑器。
+     *
+     * @param project 项目
+     * @return 编辑器
+     */
     public EditorTextField create(final Project project) {
-        return getEditorTextField(language.getFileType(), project, PsiDocumentManager.getInstance(project).getDocument(
-                PsiFileFactory.getInstance(project).createFileFromText(fileName, language.getFileType(), "")
-        ));
+        return new EditorTextField(
+                PsiDocumentManager.getInstance(project).getDocument(
+                        PsiFileFactory.getInstance(project).createFileFromText(fileName, language.getFileType(), "")
+                ),
+                project, language.getFileType(), Boolean.FALSE, Boolean.FALSE
+        ) {
+            @Override
+            protected @NotNull EditorEx createEditor() {
+                final EditorEx editor = Editor.configureEditor(project, super.createEditor(), language.getFileType());
+                // 光标置于文档开头（默认置顶）
+                editor.getCaretModel().moveToOffset(0);
+                // 实时记录视口滚动偏移（编辑器创建/页签重建时挂载）。
+                // 忽略创建初期 IntelliJ 的初始化滚动（会自动滚到文档末尾，会被误记为用户位置）
+                final long createTime = System.currentTimeMillis();
+                final ScrollingModel scrollingModel = editor.getScrollingModel();
+                scrollingModel.addVisibleAreaListener(new VisibleAreaListener() {
+                    @Override
+                    public void visibleAreaChanged(@NotNull final VisibleAreaEvent e) {
+                        if (System.currentTimeMillis() - createTime > INIT_SCROLL_IGNORE_MS) {
+                            CustomizeEditorFactory.this.initialScrollOffset = scrollingModel.getVerticalScrollOffset();
+                        }
+                    }
+                });
+                // 创建后立即执行：初始化置顶 / 还原（延迟兜底确保布局完成后生效）
+                scrollToPosition(editor);
+                return editor;
+            }
+        };
+    }
+
+    /**
+     * 滚动视口到目标位置（记录的滚动偏移或 0 置顶）。
+     *
+     * <p>EditorTextField 的视口初始化在文档末尾且滚动操作需布局完成才生效，
+     * 因此立即执行 + 延迟兜底（延迟必然成功，有轻微动画，平台限制）。
+     *
+     * @param editor 编辑器（IntelliJ Editor，与项目 Editor 接口同名冲突，此处全限定）
+     */
+    private void scrollToPosition(final com.intellij.openapi.editor.Editor editor) {
+        try {
+            final int target = Objects.requireNonNullElse(this.initialScrollOffset, 0);
+            editor.getScrollingModel().scrollVertically(target);
+            // 布局完成后延迟兜底，确保滚动生效
+            ApplicationManager.getApplication().invokeLater(() -> {
+                try {
+                    editor.getScrollingModel().scrollVertically(target);
+                } catch (final Exception ignored) {
+                }
+            });
+        } catch (final Exception ignored) {
+            // 编辑器布局未就绪时忽略，延迟兜底不依赖首次执行成功
+        }
     }
 }

--- a/src/main/java/com/acme/prism/ui/editor/Editor.java
+++ b/src/main/java/com/acme/prism/ui/editor/Editor.java
@@ -7,7 +7,6 @@ import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.command.WriteCommandAction;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.EditorSettings;
-import com.intellij.openapi.editor.ScrollType;
 import com.intellij.openapi.editor.colors.EditorColorsManager;
 import com.intellij.openapi.editor.ex.EditorEx;
 import com.intellij.openapi.editor.ex.EditorSettingsExternalizable;
@@ -29,7 +28,7 @@ import java.util.Objects;
  * @author 拒绝者
  * @date 2025-01-26
  */
-public sealed interface Editor permits CustomizeEditorFactory {
+public interface Editor {
     /**
      * 创建编辑器<br/>
      * 单页签编辑器使用
@@ -51,7 +50,7 @@ public sealed interface Editor permits CustomizeEditorFactory {
         return new EditorTextField(document, project, languageType, Boolean.FALSE, Boolean.FALSE) {
             @Override
             protected @NotNull EditorEx createEditor() {
-                return configureEditor(project, super.createEditor(), languageType);
+                return Editor.configureEditor(project, super.createEditor(), languageType);
             }
         };
     }
@@ -95,13 +94,12 @@ public sealed interface Editor permits CustomizeEditorFactory {
      * @param project 项目
      * @param editor  编辑
      */
-    default EditorEx configureEditor(final Project project, final EditorEx editor, final LanguageFileType languageType) {
+    static EditorEx configureEditor(final Project project, final EditorEx editor, final LanguageFileType languageType) {
         // 基础编辑器配置
         editor.setCaretVisible(Boolean.TRUE);
         editor.setVerticalScrollbarVisible(Boolean.TRUE);
         editor.setHorizontalScrollbarVisible(Boolean.TRUE);
         editor.setBorder(BorderFactory.createEmptyBorder());
-        editor.getScrollingModel().scrollToCaret(ScrollType.CENTER);
         // 折叠功能配置
         editor.getFoldingModel().setFoldingEnabled(Boolean.TRUE);
         // 设置菜单和交互

--- a/src/main/java/com/acme/prism/ui/editor/JsonFoldingSupport.java
+++ b/src/main/java/com/acme/prism/ui/editor/JsonFoldingSupport.java
@@ -1,0 +1,50 @@
+package com.acme.prism.ui.editor;
+
+import com.acme.prism.core.editor.JsonFoldingCalculator;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.editor.FoldRegion;
+import com.intellij.openapi.editor.FoldingModel;
+import com.intellij.openapi.util.TextRange;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+/**
+ * JSON 折叠支持：将 {@link JsonFoldingCalculator} 计算的折叠区域应用到编辑器。
+ *
+ * @author 拒绝者
+ * @date 2026-07-31
+ */
+public final class JsonFoldingSupport {
+
+    private JsonFoldingSupport() {
+    }
+
+    /**
+     * 更新编辑器折叠区域：清除旧 JSON 折叠区，按当前文本重建跨行折叠。
+     *
+     * @param editor 目标编辑器
+     * @param text   当前文档文本
+     */
+    public static void updateFolding(@NotNull final Editor editor, @NotNull final String text) {
+        final List<JsonFoldingCalculator.FoldRegion> regions = JsonFoldingCalculator.calculate(text);
+        final FoldingModel model = editor.getFoldingModel();
+        model.runBatchFoldingOperation(() -> {
+            // 清除上一次添加的折叠区域（按 placeholder 识别）
+            for (final FoldRegion region : model.getAllFoldRegions()) {
+                if (isJsonFoldRegion(region)) {
+                    model.removeFoldRegion(region);
+                }
+            }
+            // 重建折叠区域
+            for (final JsonFoldingCalculator.FoldRegion region : regions) {
+                model.addFoldRegion(region.startOffset(), region.endOffset(), region.placeholder());
+            }
+        });
+    }
+
+    private static boolean isJsonFoldRegion(final FoldRegion region) {
+        final String placeholder = region.getPlaceholderText();
+        return "{...}".equals(placeholder) || "[...]".equals(placeholder);
+    }
+}

--- a/src/main/java/com/acme/prism/ui/panel/JsonTreePanel.java
+++ b/src/main/java/com/acme/prism/ui/panel/JsonTreePanel.java
@@ -78,6 +78,10 @@ public class JsonTreePanel extends JPanel {
      */
     private static final int TREE_UPDATE_DEBOUNCE_MS = 300;
     /**
+     * 树构建跳过的大 JSON 阈值（字符），超过不做树构建，避免大文件阻塞（对齐 MainPanel 护栏）
+     */
+    private static final int MAX_TREE_CHARS = 1024 * 1024;
+    /**
      * JSON树
      */
     private final Tree jsonTree;
@@ -173,6 +177,10 @@ public class JsonTreePanel extends JPanel {
      * @param txt JSON文本
      */
     public void loadJson(final String txt) {
+        // 性能护栏：超大 JSON 跳过树构建，避免阻塞后台线程（对齐 minimap 2MB 护栏）
+        if (txt.length() > MAX_TREE_CHARS) {
+            return;
+        }
         final long sequence = this.treeSequence.incrementAndGet();
         CompletableFuture
                 .supplyAsync(() -> new DefaultTreeModel(this.buildTreeModel(JsonNodeParser.parse("root", txt))),
@@ -203,15 +211,27 @@ public class JsonTreePanel extends JPanel {
             // 随页签释放停止定时器与队列，防止泄漏
             Disposer.register(parentDisposable, () -> this.searchTimer.stop());
             EditorFactory.getInstance().getEventMulticaster().addDocumentListener(new DocumentListener() {
+                /** 上次处理的文本，内容去重避免多页签/重复事件重复构建树 */
+                private String lastProcessed = "";
+
                 @Override
                 public void documentChanged(final @NotNull DocumentEvent e) {
-                    if (e.getDocument() != editor.getDocument()) {
+                    // EditorTextField 内部存在两个 document 实例（内部 editor 与外部 PSI），
+                    // 引用比较在打字场景不可靠，改为按文本内容去重
+                    final String text = editor.getText();
+                    if (text.equals(this.lastProcessed)) {
                         return;
                     }
+                    this.lastProcessed = text;
                     // identity 固定为编辑器实例，连续变更互相合并，仅执行最后一次
-                    JsonTreePanel.this.treeUpdateQueue.queue(Update.create(editor, () -> JsonTreePanel.this.loadJson(editor.getText())));
+                    JsonTreePanel.this.treeUpdateQueue.queue(Update.create(editor, () -> JsonTreePanel.this.loadJson(text)));
                 }
             }, parentDisposable);
+            // 历史回显在面板创建前已 setText，监听器未注册收不到事件，此处主动加载一次
+            final String initial = editor.getText();
+            if (!initial.isEmpty()) {
+                this.treeUpdateQueue.queue(Update.create(editor, () -> this.loadJson(initial)));
+            }
         }
         // 创建树面板
         final JPanel panel = new JPanel(new BorderLayout(0, 0));

--- a/src/main/java/com/acme/prism/ui/panel/MainPanel.java
+++ b/src/main/java/com/acme/prism/ui/panel/MainPanel.java
@@ -8,6 +8,7 @@ import com.acme.prism.core.parser.AnyParser;
 import com.acme.prism.core.parser.JwtParser;
 import com.acme.prism.core.parser.PathParser;
 import com.acme.prism.ui.dialog.ConvertAnyDialog;
+import com.acme.prism.ui.editor.JsonFoldingSupport;
 import com.alibaba.fastjson2.JSON;
 import com.intellij.diff.DiffContentFactory;
 import com.intellij.diff.DiffManager;
@@ -83,6 +84,11 @@ public class MainPanel {
      * JSON 文件扩展名
      */
     private static final String JSON_EXTENSION = "json";
+    /**
+     * 自动识别与树构建跳过的大 JSON 阈值（字符）。超过该长度的文本不做自动识别/树构建，
+     * 避免大文件粘贴或加载时阻塞 UI（对齐 minimap 2MB / 彩虹变量 2 万行的护栏策略）
+     */
+    private static final int MAX_AUTO_PROCESS_CHARS = 1024 * 1024;
     /**
      * 编辑器弹出菜单名称
      */
@@ -461,32 +467,43 @@ public class MainPanel {
                     "JsonHelper.AutoDetect", AUTO_DETECT_DEBOUNCE_MS, Boolean.TRUE, null, parentDisposable, null, Alarm.ThreadToUse.POOLED_THREAD
             );
             EditorFactory.getInstance().getEventMulticaster().addDocumentListener(new DocumentListener() {
+                /** 上次处理的文本，内容去重避免多页签/重复事件重复触发 */
+                private String lastProcessed = "";
+
                 @Override
                 public void documentChanged(final @NotNull DocumentEvent e) {
-                    if (e.getDocument() != editor.getDocument()) {
+                    // EditorTextField 内部存在两个 document 实例（内部 editor 与外部 PSI），
+                    // 引用比较在打字场景不可靠，改为按文本内容去重
+                    final String text = editor.getText();
+                    if (text.equals(this.lastProcessed)) {
                         return;
                     }
-                    // 获取新旧片段并预处理
+                    this.lastProcessed = text;
+                    // 获取新旧片段并预处理（用事件片段判断是否纯空白差异）
                     final CharSequence oldText = e.getOldFragment();
                     final CharSequence newText = e.getNewFragment();
-                    // 内容无变化时直接跳过
                     if (CharSequence.compare(oldText, newText) == 0) {
                         return;
                     }
-                    // 忽略纯空白差异
                     if (StrUtil.emptyIfNull(oldText).strip().equals(StrUtil.emptyIfNull(newText).strip())) {
                         return;
                     }
-                    // 文档内容
-                    final String text = StrUtil.emptyIfNull(e.getDocument().getText());
                     // 根据文档内容调整清空按钮的状态
                     clearButton.setEnabled(!StrUtil.isEmpty(text));
+                    // 性能护栏：超大 JSON 跳过自动识别，避免阻塞后台线程与 EDT
+                    if (text.length() > MAX_AUTO_PROCESS_CHARS) {
+                        return;
+                    }
                     if (MainPanel.this.autoDetectApplying.get()) {
                         return;
                     }
-                    // 防抖调度：自动识别路径类型（Web或本地路径）、Jwt、Any并将其转换为格式化JSON，回写到编辑器
+                    // 防抖调度：自动识别路径类型（Web或本地路径）、Jwt、Any并将其转换为格式化JSON，回写到编辑器；
+                    // 折叠更新并入同一队列（POOLED 线程执行 JSON 校验，避免大文本全量解析阻塞 EDT）
                     // identity 固定为编辑器实例，连续输入事件互相合并，仅执行最后一次
-                    MainPanel.this.autoDetectQueue.queue(Update.create(editor, () -> MainPanel.this.optPath(text, editor)));
+                    MainPanel.this.autoDetectQueue.queue(Update.create(editor, () -> {
+                        MainPanel.this.updateFolding(editor, text);
+                        MainPanel.this.optPath(text, editor);
+                    }));
                 }
             }, parentDisposable);
         }
@@ -547,6 +564,10 @@ public class MainPanel {
      * @param editor 目标编辑器组件, 用于回写处理结果
      */
     private void optPath(final String text, final EditorTextField editor) {
+        // 性能护栏：超大文本不做自动识别（与 documentChanged 双保险）
+        if (text.length() > MAX_AUTO_PROCESS_CHARS) {
+            return;
+        }
         final long sequence = this.autoDetectSequence.incrementAndGet();
         CompletableFuture.supplyAsync(() -> {
                     final String result = this.resolveJson(text);
@@ -580,6 +601,26 @@ public class MainPanel {
             return jwtResult;
         }
         return AnyParser.convert(text);
+    }
+
+    /**
+     * 更新编辑器 JSON 折叠区域：仅当文本为合法 JSON 且含换行时生效（压缩单行不折叠）。
+     * 由防抖队列在后台线程调用（JSON 校验不阻塞 EDT），折叠模型应用切回 EDT。
+     *
+     * @param editor 编辑器
+     * @param text   当前文本
+     */
+    private void updateFolding(final EditorTextField editor, final String text) {
+        if (text.indexOf('\n') < 0 || !JSON.isValid(text)) {
+            return;
+        }
+        // EditorTextField 的内部 Editor 可能尚未创建，延迟到 EDT 获取
+        ApplicationManager.getApplication().invokeLater(() -> {
+            if (Objects.isNull(editor.getEditor())) {
+                return;
+            }
+            JsonFoldingSupport.updateFolding(editor.getEditor(), editor.getText());
+        });
     }
 
     /**

--- a/src/test/java/com/acme/prism/core/editor/JsonFoldingCalculatorTest.java
+++ b/src/test/java/com/acme/prism/core/editor/JsonFoldingCalculatorTest.java
@@ -1,0 +1,84 @@
+package com.acme.prism.core.editor;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * JsonFoldingCalculator 单元测试：跨行括号对折叠区域计算。
+ *
+ * @author 拒绝者
+ * @date 2026-07-31
+ */
+class JsonFoldingCalculatorTest {
+
+    @Test
+    @DisplayName("正常：格式化 JSON 的对象跨行可折叠")
+    void formattedObjectFoldable() {
+        final String json = "{\n  \"a\": 1\n}";
+        final List<JsonFoldingCalculator.FoldRegion> regions = JsonFoldingCalculator.calculate(json);
+        assertAll(
+                () -> assertEquals(1, regions.size(), "一个跨行对象应产生一个折叠区"),
+                () -> assertEquals(0, regions.getFirst().startOffset()),
+                () -> assertEquals(json.length(), regions.getFirst().endOffset()),
+                () -> assertEquals("{...}", regions.getFirst().placeholder())
+        );
+    }
+
+    @Test
+    @DisplayName("正常：嵌套对象产生多个折叠区域（外层+内层）")
+    void nestedObjectsMultipleRegions() {
+        final String json = "{\n  \"a\": {\n    \"b\": 1\n  }\n}";
+        final List<JsonFoldingCalculator.FoldRegion> regions = JsonFoldingCalculator.calculate(json);
+        assertEquals(2, regions.size(), "外层与内层对象都应可折叠");
+        // 内层区间应在外层区间内部
+        assertTrue(regions.getFirst().startOffset() < regions.getLast().startOffset(),
+                "外层折叠区应包含内层折叠区");
+    }
+
+    @Test
+    @DisplayName("正常：数组跨行可折叠")
+    void formattedArrayFoldable() {
+        final String json = "[\n  1,\n  2\n]";
+        final List<JsonFoldingCalculator.FoldRegion> regions = JsonFoldingCalculator.calculate(json);
+        assertAll(
+                () -> assertEquals(1, regions.size()),
+                () -> assertEquals("[...]", regions.getFirst().placeholder())
+        );
+    }
+
+    @Test
+    @DisplayName("边界：压缩单行 JSON 无可折叠区域")
+    void compactJsonNoFoldRegion() {
+        final String json = "{\"a\":{\"b\":1},\"c\":[1,2]}";
+        assertTrue(JsonFoldingCalculator.calculate(json).isEmpty(),
+                "单行 JSON 不应产生折叠区域");
+    }
+
+    @Test
+    @DisplayName("边界：字符串内的括号不参与折叠")
+    void bracesInsideStringIgnored() {
+        // 字符串 {"fake"} 内含括号，不应误判为折叠点
+        final String json = "{\n  \"a\": \"{\\\"fake\\\"}\"\n}";
+        final List<JsonFoldingCalculator.FoldRegion> regions = JsonFoldingCalculator.calculate(json);
+        assertEquals(1, regions.size(), "仅外层对象可折叠，字符串内括号应忽略");
+    }
+
+    @Test
+    @DisplayName("边界：null 与空串返回空列表")
+    void blankInputReturnsEmpty() {
+        assertTrue(JsonFoldingCalculator.calculate(null).isEmpty());
+        assertTrue(JsonFoldingCalculator.calculate("").isEmpty());
+    }
+
+    @Test
+    @DisplayName("边界：非法 JSON 括号不匹配时安全返回（不抛异常）")
+    void unbalancedBracesSafeReturn() {
+        final String json = "{\n  \"a\": 1\n";
+        assertDoesNotThrow(() -> JsonFoldingCalculator.calculate(json),
+                "括号不匹配不应抛异常");
+    }
+}

--- a/src/test/java/com/acme/prism/core/editor/record/EditorStateTest.java
+++ b/src/test/java/com/acme/prism/core/editor/record/EditorStateTest.java
@@ -116,6 +116,63 @@ class EditorStateTest {
     }
 
     @Test
+    @DisplayName("正常：带滚动位置的记录编码解码往返一致")
+    void roundTripsWithScrollOffset() {
+        final EditorState state = new EditorState(5, "{\"a\":1}", 1234);
+        final List<EditorState> decoded = EditorState.decode(EditorState.encode(List.of(state)));
+        assertAll(
+                () -> assertEquals(1, decoded.size()),
+                () -> assertEquals(1234, decoded.getFirst().scrollOffset(), "滚动位置应无损往返")
+        );
+    }
+
+    @Test
+    @DisplayName("兼容：旧格式（无滚动位置段）解码后 scrollOffset 为 null")
+    void decodesLegacyTwoSegmentFormat() {
+        // 旧版本只存 id + content 两段，无第三段滚动位置
+        final String legacy = "1\u001FeyJhIjoxfQ==";
+        final List<EditorState> decoded = EditorState.decode(legacy);
+        assertAll(
+                () -> assertEquals(1, decoded.size()),
+                () -> assertEquals(1, decoded.getFirst().editorId()),
+                () -> assertEquals("{\"a\":1}", decoded.getFirst().content()),
+                () -> assertNull(decoded.getFirst().scrollOffset(), "旧数据滚动位置应为 null，恢复时默认置顶")
+        );
+    }
+
+    @Test
+    @DisplayName("兼容：三参 null 滚动位置与双参构造等价")
+    void nullScrollOffsetEquivalent() {
+        final EditorState withNull = new EditorState(1, "x", null);
+        final EditorState legacy = new EditorState(1, "x");
+        assertEquals(legacy, withNull, "null 滚动位置应与双参构造等价");
+        assertEquals(legacy, EditorState.decode(EditorState.encode(List.of(withNull))).getFirst(),
+                "null 滚动位置编码解码后应保持 null");
+    }
+
+    @Test
+    @DisplayName("正常：带光标位置的记录编码解码往返一致")
+    void roundTripsWithCaretOffset() {
+        final EditorState state = new EditorState(6, "{\"a\":1}", null, 42);
+        final List<EditorState> decoded = EditorState.decode(EditorState.encode(List.of(state)));
+        assertAll(
+                () -> assertEquals(1, decoded.size()),
+                () -> assertEquals(42, decoded.getFirst().caretOffset(), "光标位置应无损往返")
+        );
+    }
+
+    @Test
+    @DisplayName("兼容：旧格式（无光标段）解码后 caretOffset 为 null")
+    void decodesLegacyFormatCaretNull() {
+        // 旧版本只存 id + content 两段
+        final List<EditorState> decoded = EditorState.decode("1\u001FeyJhIjoxfQ==");
+        assertAll(
+                () -> assertEquals(1, decoded.size()),
+                () -> assertNull(decoded.getFirst().caretOffset(), "旧数据光标位置应为 null")
+        );
+    }
+
+    @Test
     @DisplayName("边界：decode 对非数字编辑器 ID 容错为 null")
     void decodeToleratesNonNumericEditorId() {
         final List<EditorState> decoded = EditorState.decode("abc\u001FaGVsbG8=");


### PR DESCRIPTION
- JSON 折叠：JsonFoldingCalculator（纯逻辑括号匹配）+ JsonFoldingSupport（FoldingModel 应用），多行对象/数组可折叠，字符串内括号忽略
- 性能护栏：MainPanel/JsonTreePanel 超过 1MB 的 JSON 跳过自动识别与树构建，避免大文件阻塞 UI
- 视口记忆：VisibleAreaListener 实时记录滚动偏移，页签切换与项目重开均还原视口位置；无记录默认置顶；忽略创建初期平台初始化滚动（500ms 时间窗）
- 树面板刷新：文档监听改内容去重（替代失效的引用比较），历史回显在面板创建后主动加载
- EDT 优化：折叠校验并入防抖队列后台线程执行，避免大文本全量解析阻塞 EDT