### PR TITLE
build: 升级 fastjson2 至 2.0.64，发布 0.19.7

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@
 | IntelliJ Platform       | 2026.2 | IDE 集成                 |
 | Hutool                  | 5.8.47 | 工具库（core + http）    |
 | Jackson                 | 3.2.1  | JSON/数据格式处理（BOM） |
-| Fastjson2               | 2.0.62 | JSON 解析与校验          |
+| Fastjson2               | 2.0.64 | JSON 解析与校验          |
 | Auth0 JWT               | 4.5.2  | JWT Token 解析           |
 | Apache POI              | 5.5.1  | Excel 文件支持           |
 | Apache Commons Compress | 1.28.0 | 压缩包格式支持           |
@@ -454,12 +454,12 @@ EDT 线程读取文档 + 150ms 防抖，大文件自动跳过，支持点击/拖
 3. **剪贴板操作**: 需用户显式触发
 4. **文件操作**: 处理前校验 JSON 格式
 5. **压缩包解压**: 对单文件压缩设置压缩率兜底防护，防止解压炸弹；大文件/条目大小限制在打开器与搜索索引中均有护栏
-6. **Fastjson2 AutoType 安全**: 2026-07-27 披露 fastjson2 ≤ 2.0.62 的 FNV-1a 哈希碰撞可绕过 AutoType 校验（XVE-2026-42782，CVSS 9.8）。
+6. **Fastjson2 AutoType 安全**: 2026-07-27 披露 fastjson2 ≤ 2.0.62 的 FNV-1a 哈希碰撞可绕过 AutoType 校验（XVE-2026-42782，CVSS 9.8），已在 **2.0.63** 修复（白名单 hash 命中后文本回验、URL 特殊字符类型名拒绝、accept 前缀不再覆盖 ClassLoader/DataSource/RowSet 危险基类）。
+   - **当前版本**: 已升级至 2.0.64（2.0.63 安全修复 + 2.0.64 JSONB OOM/DoS、Metaspace 泄漏、record 泛型等修复）
    - **默认安全**: fastjson2 默认关闭 AutoType，本插件的所有 JSON 解析（`JSON.parse()` / `JSON.parseObject()` 不传 `SupportAutoType`）不受影响
-   - **纵深防御**: Gradle 的 `runIde` 和 `test` 任务均配置 JVM 参数 `-Dfastjson2.parser.safeMode=true`
-   - **已知限制**: 2.0.62 的 SafeMode 仅有 JVM 参数方式（无编程式 API），且无法阻止显式传入 `SupportAutoType`
-   - **待升级**: 关注 [fastjson2 修复版本](https://github.com/alibaba/fastjson2) 发布后，更新 `settings.gradle` 中的 `fastjson2` 版本号
-   - **测试覆盖**: `JsonSafeModeTest` 记录当前安全基线与已知缺陷，供升级后回归对比
+   - **纵深防御**: Gradle 的 `runIde` 和 `test` 任务均配置 JVM 参数 `-Dfastjson2.parser.safeMode=true`；实测 2.0.62/2.0.64 下 SafeMode 开启时显式传入 `SupportAutoType` 同样不实例化 @type（结果恒为 `JSONObject`）
+   - **已知限制**: SafeMode 仅有 JVM 参数与编程式 `JSON.configSafeMode()` 两种方式，无法阻止在 AutoType 白名单场景下的合法放行；XVE-2026-42782 影响的是 AutoType 白名单场景，本插件从不开启 AutoType，攻击面极小
+   - **测试覆盖**: `JsonSafeModeTest` 守护安全基线（默认配置与 SafeMode 下 @type 均不实例化，含危险类名回归用例）；注意 `JSONObject extends LinkedHashMap`，断言必须用 `getClass() == JSONObject.class` 精确类型，`assertInstanceOf(HashMap.class)` 恒真无区分能力
 
 ## 相关文档
 

--- a/README.md
+++ b/README.md
@@ -69,23 +69,31 @@ build/distributions/prism-x.x.x.zip
 ## 项目结构
 
 ```text
-src/main/java/com/acme/json/helper
+src/main/java/com/acme/prism
 ├── common
+│   └── enums
 ├── core
-│   ├── editor
-│   ├── json
-│   ├── notice
-│   ├── parser
+│   ├── archive      # 压缩包索引/树节点/搜索/打开器
+│   ├── console      # 控制台 JSON 推送
+│   ├── editor       # JSON 折叠、编辑器状态
+│   ├── fileinfo     # 项目树文件信息
+│   ├── json         # JSON 操作（格式化/压缩/转义/搜索）
+│   ├── minimap      # 代码地图
+│   ├── notice       # 通知系统
+│   ├── parser       # 解析与格式转换
 │   │   └── converter
-│   ├── screenshot
-│   ├── search
-│   └── settings
+│   ├── rainbow      # 彩虹括号/变量/颜色高亮
+│   ├── screenshot   # 代码截图
+│   ├── search       # 项目/HTTP/端口/压缩包搜索
+│   └── settings     # 插件设置
 └── ui
-    ├── action
-    ├── dialog
-    ├── editor
-    ├── panel
-    └── search
+    ├── action       # 动作（json/搜索/截图/console）
+    ├── dialog       # 转换/建类对话框
+    ├── editor       # 面板编辑器定制
+    ├── error        # JSON 语法错误标注
+    ├── panel        # 主面板/JSON 树面板
+    ├── search       # Search Everywhere 工厂
+    └── statusbar    # 状态栏 JSON 路径面包屑
 ```
 
 ## CI / Release

--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,11 @@ intellijPlatform {
         version = project.version.toString()
         // sinceBuild 自 IGP 2.14 起默认取目标平台 major build（2026.2 → 262），无需显式声明
         changeNotes = """
+            <b>0.19.7</b>
+            <ul>
+                <li>安全升级：fastjson2 2.0.62 → 2.0.64，修复 XVE-2026-42782 AutoType 白名单 hash 碰撞绕过（2.0.63 官方修复：白名单文本回验、URL 特殊字符类型名拒绝、危险基类前缀防护），并附带 JSONB OOM/DoS、Metaspace 泄漏、record 泛型等修复。</li>
+                <li>安全测试修正：JsonSafeModeTest 重写有效断言（JSONObject extends LinkedHashMap，旧 assertInstanceOf(HashMap.class) 恒真无区分能力），实测 SafeMode 下显式 SupportAutoType 也不实例化 @type，新增危险类名回归用例。</li>
+            </ul>
             <b>0.19.6</b>
             <ul>
                 <li>JSON 编辑器折叠：多行 JSON 自动生成可折叠区间（对象/数组括号对，字符串内括号忽略）。</li>

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 // 统一版本表：插件版本、目标平台、Java 基线与第三方依赖版本在此集中维护
 gradle.ext.versions = [
         // 插件版本：发布新版本时递增，并同步更新 build.gradle 中的 changeNotes
-        ver         : "0.19.6",
+        ver         : "0.19.7",
         // 目标 IntelliJ 平台版本：sinceBuild 自 IGP 2.14 起默认取平台 major build（2026.2 → 262），无需显式声明
         idea        : "2026.2",
         // Java 语言基线：toolchain 与 options.release 共用
@@ -27,7 +27,7 @@ gradle.ext.versions = [
         hutool      : "5.8.47",
         jackson     : "3.2.1",
         apachePoi   : "5.5.1",
-        fastjson2   : "2.0.62",
+        fastjson2   : "2.0.64",
         junit       : "6.1.2",
         commonsLang3: "3.20.0",
         commonsCompress: "1.28.0"

--- a/src/test/java/com/acme/prism/core/json/JsonSafeModeTest.java
+++ b/src/test/java/com/acme/prism/core/json/JsonSafeModeTest.java
@@ -11,13 +11,27 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * fastjson2 安全性验证测试。
  *
- * <p>验证 fastjson2 2.0.62 在默认配置下的安全行为，并记录当前 SafeMode JVM 参数
- *（{@code -Dfastjson2.parser.safeMode=true}）的实际效果差异，供升级后回归对比。
+ * <p>验证 fastjson2 在默认配置与 SafeMode（{@code -Dfastjson2.parser.safeMode=true}）
+ * 下的安全行为，守护插件的安全姿态并防止升级引入回归。
  *
- * <p>背景：2026-07-27 披露 fastjson2 ≤ 2.0.62 的 FNV-1a 哈希碰撞可绕过 AutoType 校验
- *（XVE-2026-42782，CVSS 9.8）。本插件仅做纯数据层面的 JSON 解析/格式化，不涉及
- * Polymorphic 类型反序列化，因此攻击面极小。通过 Gradle test/runIde 配置
- * {@code -Dfastjson2.parser.safeMode=true} 作为纵深防御，并等待官方修复版本。
+ * <p>安全基线（实测于 2.0.62 与 2.0.64，测试任务 JVM 参数开启 SafeMode）：
+ * <ul>
+ *   <li>默认配置（不传 SupportAutoType，即插件全部实际用法）：@type 仅作普通字段解析，从不实例化类。</li>
+ *   <li>SafeMode 开启时，显式传 {@link JSONReader.Feature#SupportAutoType} 同样不实例化 @type
+ *       ——结果恒为 {@link JSONObject}。</li>
+ * </ul>
+ *
+ * <p>漏洞背景：2026-07-27 披露 fastjson2 ≤ 2.0.62 的 FNV-1a 哈希碰撞可绕过 AutoType
+ * 白名单校验（XVE-2026-42782，CVSS 9.8），已在 2.0.63 修复（白名单 hash 命中后文本回验、
+ * URL 特殊字符类型名拒绝、accept 前缀不再覆盖 ClassLoader/DataSource/RowSet 危险基类）。
+ * 该漏洞影响的是 AutoType 白名单场景；本插件从不开启 AutoType，叠加 SafeMode 纵深防御，
+ * 攻击面极小。升级 2.0.64 除获得该修复外，还附带 JSONB OOM/DoS、Metaspace 泄漏、
+ * record 泛型等多项修复。
+ *
+ * <p>断言说明：fastjson2 的 {@link JSONObject} 继承自 {@link java.util.LinkedHashMap}，
+ * 因此 {@code assertInstanceOf(HashMap.class, result)} 恒真、无法区分 JSONObject 与
+ * 真正的 @type 实例（旧版测试即因此误报"SafeMode 可被绕过"）。本测试统一断言
+ * {@code result.getClass() == JSONObject.class} 精确类型以消除歧义。
  *
  * @author 拒绝者
  * @date 2026-07-29
@@ -35,25 +49,44 @@ class JsonSafeModeTest {
         assertEquals("java.util.HashMap", result.getString("@type"),
                 "默认配置下 @type 应被当作普通字符串字段");
         assertEquals("value", result.getString("key"));
-        assertInstanceOf(JSONObject.class, result, "默认配置下结果应为 JSONObject，非 @type 指定的类实例");
+        assertEquals(JSONObject.class, result.getClass(),
+                "默认配置下结果应为 JSONObject，非 @type 指定的类实例");
     }
 
     @Test
-    @DisplayName("已知缺陷（2.0.62）：显式 SupportAutoType 在 SafeMode 下仍可解析 @type —— 等待官方修复")
+    @DisplayName("安全：SafeMode 下显式 SupportAutoType 也不实例化 @type（2.0.63+ 官方修复后实测）")
     @SuppressWarnings("deprecation")
-    void explicitAutoTypeStillWorksUnderSafeMode_knownIssue() {
-        // 记录 fastjson2 2.0.62 的实际行为作为基线：
-        // 即使设置了 -Dfastjson2.parser.safeMode=true，显式传 SupportAutoType 仍会绕过。
-        // 升级到修复版本后，此测试需要改为断言 @type 被阻止。
+    void explicitSupportAutoTypeBlockedUnderSafeMode() {
+        // 实测（SafeMode JVM 参数开启）：2.0.62 与 2.0.64 下显式传 SupportAutoType，
+        // 无论 @type 指向内置安全类（HashMap）还是不存在的类/危险基类（ClassLoader 等），
+        // 结果恒为 JSONObject，不触发任何类实例化。
         final String jsonWithType = "{\"@type\":\"java.util.HashMap\",\"key\":\"value\"}";
         final Object result = JSON.parseObject(jsonWithType, Object.class, JSONReader.Feature.SupportAutoType);
 
         assertNotNull(result);
-        // 2.0.62 的行为：SafeMode JVM 参数不能阻止显式 SupportAutoType
-        // 修复版本发布后应改为 assertInstanceOf(JSONObject.class, result)
-        assertInstanceOf(java.util.HashMap.class, result,
-                "2.0.62 已知缺陷：SafeMode 无法阻止显式 SupportAutoType。"
-                        + "升级后此断言应改为 JSONObject.class");
+        assertEquals(JSONObject.class, result.getClass(),
+                "SafeMode 下显式 SupportAutoType 不得绕过：结果应为 JSONObject，而非 @type 类实例");
+        assertEquals("java.util.HashMap", ((JSONObject) result).getString("@type"),
+                "@type 应保留为普通字段");
+    }
+
+    @Test
+    @DisplayName("安全：SafeMode 下危险类名（不存在的类/危险基类）同样不实例化")
+    @SuppressWarnings("deprecation")
+    void dangerousTypeNamesNotInstantiatedUnderSafeMode() {
+        // 覆盖 XVE-2026-42782 关注面：非白名单/危险基类即使在显式 SupportAutoType 下
+        // 也只解析为 JSONObject，类加载路径不被触碰。
+        final String[] dangerousPayloads = {
+                "{\"@type\":\"com.example.NonExistentEvil\",\"a\":1}",
+                "{\"@type\":\"javax.sql.DataSource\",\"a\":1}",
+                "{\"@type\":\"java.lang.ClassLoader\",\"a\":1}",
+                "{\"@type\":\"java.net.URL\",\"a\":1}"
+        };
+        for (final String payload : dangerousPayloads) {
+            final Object result = JSON.parseObject(payload, Object.class, JSONReader.Feature.SupportAutoType);
+            assertEquals(JSONObject.class, result.getClass(),
+                    "危险类型名不得实例化: " + payload);
+        }
     }
 
     @Test
@@ -65,7 +98,7 @@ class JsonSafeModeTest {
         final Object parsed = JSON.parse(maliciousJson);
 
         assertNotNull(parsed);
-        assertInstanceOf(JSONObject.class, parsed);
+        assertEquals(JSONObject.class, parsed.getClass());
 
         // 序列化也正常
         final String output = JSON.toJSONString(parsed);


### PR DESCRIPTION
- settings.gradle: fastjson2 2.0.62 → 2.0.64，插件版本 0.19.6 → 0.19.7
- 安全升级背景: XVE-2026-42782（CVSS 9.8）AutoType 白名单 FNV-1a 哈希碰撞绕过，2.0.63 官方修复（白名单 hash 命中文本回验、URL 特殊字符类型名拒绝、accept 前缀不再覆盖 ClassLoader/DataSource/RowSet 危险基类）；2.0.64 附带 JSONB OOM/DoS、Metaspace 泄漏、record 泛型修复
- JsonSafeModeTest 断言修正: JSONObject extends LinkedHashMap extends HashMap，旧 assertInstanceOf(HashMap.class) 恒真无区分能力，改为 getClass() == JSONObject.class 精确断言；实测 2.0.62/2.0.64 SafeMode 下显式 SupportAutoType 均不实例化 `@type`，新增危险类名回归用例
- AGENTS.md: 依赖表与安全章节同步（移除待升级标注，记录 2.0.64 基线与断言注意点）
- README.md: 项目结构路径修正 com/acme/json/helper → com/acme/prism