### PR TITLE
feat: JSON Schema 校验与创建类弹窗升级，发布 0.20.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,13 @@ intellijPlatform {
         version = project.version.toString()
         // sinceBuild 自 IGP 2.14 起默认取目标平台 major build（2026.2 → 262），无需显式声明
         changeNotes = """
+            <b>0.20.5</b>
+            <ul>
+                <li>JSON Schema 校验：新增 JsonSchemaValidator（type/required/enum/范围/items/pattern 逐字段校验）与校验弹窗（目标 JSON 自动带入、Schema 自动识别或一键生成、失败项表格展示），工具条新增校验按钮。</li>
+                <li>创建类弹窗升级：JSON 输入改为语法高亮编辑器，布局重构（类型/类名一行 + 编辑区占主体）。</li>
+                <li>编辑器创建统一收敛至 Editor.createEditorField（转换/校验/建类对话框复用单一入口）。</li>
+                <li>插件描述补充 analyze/schema/mock/SQL 关键词；校验结果区修复（高度与中文空状态）。</li>
+            </ul>
             <b>0.20.0</b>
             <ul>
                 <li>右侧面板深度工具：修复（损坏 JSON 自动修复，置信度评分+修复日志+低置信度警告）、按键排序、压平/还原、JSON Schema（Draft 7）生成、Mock 数据生成、结构分析（统计+重复键检测）。</li>

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 // 统一版本表：插件版本、目标平台、Java 基线与第三方依赖版本在此集中维护
 gradle.ext.versions = [
         // 插件版本：发布新版本时递增，并同步更新 build.gradle 中的 changeNotes
-        ver         : "0.20.0",
+        ver         : "0.20.5",
         // 目标 IntelliJ 平台版本：sinceBuild 自 IGP 2.14 起默认取平台 major build（2026.2 → 262），无需显式声明
         idea        : "2026.2",
         // Java 语言基线：toolchain 与 options.release 共用

--- a/src/main/java/com/acme/prism/core/json/JsonSchemaValidator.java
+++ b/src/main/java/com/acme/prism/core/json/JsonSchemaValidator.java
@@ -1,0 +1,290 @@
+package com.acme.prism.core.json;
+
+import cn.hutool.core.convert.Convert;
+import cn.hutool.core.util.StrUtil;
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONArray;
+import com.alibaba.fastjson2.JSONObject;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+/**
+ * JSON Schema 校验器：按 JSON Schema（Draft 7 常用关键字）逐字段校验 JSON 数据。
+ *
+ * <p>支持关键字：type（含多类型数组）、required、properties、items、enum、
+ * minLength/maxLength、minimum/maximum、pattern。输出每个失败项（路径/期望/实际/说明）
+ * 与已校验字段总数。</p>
+ *
+ * @author 拒绝者
+ * @date 2026-08-05
+ */
+public final class JsonSchemaValidator {
+
+    /**
+     * 校验失败项。
+     *
+     * @param path     JSONPath 路径（如 {@code $.user.name}）
+     * @param expected 期望
+     * @param actual   实际
+     * @param message  失败说明
+     */
+    public record ValidationIssue(String path, String expected, String actual, String message) {
+    }
+
+    /**
+     * 校验结果。
+     *
+     * @param issues      失败项列表（校验通过为空列表）
+     * @param checkedCount 已校验字段/值总数（用于汇总展示）
+     */
+    public record ValidationOutcome(List<ValidationIssue> issues, int checkedCount) {
+    }
+
+    /**
+     * 校验 JSON 数据是否符合 Schema。
+     *
+     * @param json   JSON 数据
+     * @param schema JSON Schema（对象形式）
+     * @return 校验结果；输入为空或解析失败时返回解析失败项
+     */
+    public static ValidationOutcome validate(final String json, final String schema) {
+        if (StrUtil.isBlank(json) || StrUtil.isBlank(schema)) {
+            return new ValidationOutcome(List.of(), 0);
+        }
+        final Object jsonValue;
+        final JSONObject schemaObj;
+        try {
+            jsonValue = JSON.parse(json);
+            schemaObj = JSON.parseObject(schema);
+        } catch (final Exception ignored) {
+            return new ValidationOutcome(
+                    List.of(new ValidationIssue("$", "合法 JSON 与 Schema", "解析失败", "JSON 或 Schema 无法解析")),
+                    0
+            );
+        }
+        if (Objects.isNull(schemaObj)) {
+            return new ValidationOutcome(
+                    List.of(new ValidationIssue("$", "Schema 对象", "非对象", "Schema 必须是 JSON 对象")),
+                    0
+            );
+        }
+        final List<ValidationIssue> issues = new ArrayList<>();
+        final AtomicInteger checked = new AtomicInteger();
+        validateValue(jsonValue, schemaObj, "$", issues, checked);
+        return new ValidationOutcome(issues, checked.get());
+    }
+
+    /**
+     * 递归校验值。
+     *
+     * @param value      实际值
+     * @param schemaNode Schema 节点
+     * @param path       当前路径
+     * @param issues     失败项收集器
+     * @param checked    已校验计数
+     */
+    private static void validateValue(final Object value, final JSONObject schemaNode, final String path,
+                                      final List<ValidationIssue> issues, final AtomicInteger checked) {
+        checked.incrementAndGet();
+        // 1. 类型校验（失败后跳过其余关键字，避免连环误报）
+        final Object type = schemaNode.get("type");
+        if (Objects.nonNull(type) && !matchesType(value, type)) {
+            issues.add(new ValidationIssue(path, "类型 " + type, actualType(value), "类型不匹配"));
+            return;
+        }
+        // 2. 枚举校验
+        final JSONArray enumValues = schemaNode.getJSONArray("enum");
+        if (Objects.nonNull(enumValues) && !enumValues.contains(value)) {
+            issues.add(new ValidationIssue(path, "枚举值之一", String.valueOf(value), "不在枚举范围内"));
+        }
+        // 3. 字符串约束
+        if (value instanceof final String text) {
+            validateString(text, schemaNode, path, issues);
+        }
+        // 4. 数字约束
+        if (value instanceof final Number number) {
+            validateNumber(number, schemaNode, path, issues);
+        }
+        // 5. 对象：必填字段 + 子属性递归
+        if (value instanceof final JSONObject obj) {
+            validateObject(obj, schemaNode, path, issues, checked);
+        }
+        // 6. 数组：元素递归
+        if (value instanceof final JSONArray arr) {
+            final Object items = schemaNode.get("items");
+            if (items instanceof final JSONObject itemSchema) {
+                for (int index = 0; index < arr.size(); index++) {
+                    validateValue(arr.get(index), itemSchema, "%s[%d]".formatted(path, index), issues, checked);
+                }
+            }
+        }
+    }
+
+    /**
+     * 校验字符串约束。
+     *
+     * @param text       字符串
+     * @param schemaNode Schema 节点
+     * @param path       路径
+     * @param issues     失败项收集器
+     */
+    private static void validateString(final String text, final JSONObject schemaNode, final String path,
+                                       final List<ValidationIssue> issues) {
+        final Integer minLength = schemaNode.getInteger("minLength");
+        if (Objects.nonNull(minLength) && text.length() < minLength) {
+            issues.add(new ValidationIssue(path, "长度 ≥ %d".formatted(minLength), String.valueOf(text.length()), "字符串过短"));
+        }
+        final Integer maxLength = schemaNode.getInteger("maxLength");
+        if (Objects.nonNull(maxLength) && text.length() > maxLength) {
+            issues.add(new ValidationIssue(path, "长度 ≤ %d".formatted(maxLength), String.valueOf(text.length()), "字符串过长"));
+        }
+        final String pattern = schemaNode.getString("pattern");
+        if (StrUtil.isNotBlank(pattern)) {
+            try {
+                if (!Pattern.compile(pattern).matcher(text).matches()) {
+                    issues.add(new ValidationIssue(path, "匹配 " + pattern, text, "不匹配正则"));
+                }
+            } catch (final PatternSyntaxException ignored) {
+                // Schema 中非法正则忽略，不中断校验
+            }
+        }
+    }
+
+    /**
+     * 校验数字约束。
+     *
+     * @param number     数字
+     * @param schemaNode Schema 节点
+     * @param path       路径
+     * @param issues     失败项收集器
+     */
+    private static void validateNumber(final Number number, final JSONObject schemaNode, final String path,
+                                       final List<ValidationIssue> issues) {
+        final BigDecimal value = BigDecimal.valueOf(number.doubleValue());
+        final BigDecimal minimum = toBigDecimal(schemaNode.get("minimum"));
+        if (Objects.nonNull(minimum) && value.compareTo(minimum) < 0) {
+            issues.add(new ValidationIssue(path, "≥ " + minimum.toPlainString(), String.valueOf(number), "小于最小值"));
+        }
+        final BigDecimal maximum = toBigDecimal(schemaNode.get("maximum"));
+        if (Objects.nonNull(maximum) && value.compareTo(maximum) > 0) {
+            issues.add(new ValidationIssue(path, "≤ " + maximum.toPlainString(), String.valueOf(number), "大于最大值"));
+        }
+    }
+
+    /**
+     * 校验对象：必填字段与子属性递归。
+     *
+     * @param obj        对象
+     * @param schemaNode Schema 节点
+     * @param path       路径
+     * @param issues     失败项收集器
+     * @param checked    已校验计数
+     */
+    private static void validateObject(final JSONObject obj, final JSONObject schemaNode, final String path,
+                                       final List<ValidationIssue> issues, final AtomicInteger checked) {
+        final JSONArray required = schemaNode.getJSONArray("required");
+        if (Objects.nonNull(required)) {
+            for (final Object item : required) {
+                final String key = Convert.toStr(item);
+                if (!obj.containsKey(key)) {
+                    issues.add(new ValidationIssue(path, "必填字段 " + key, "缺失", "缺少必填字段 " + key));
+                }
+            }
+        }
+        final JSONObject properties = schemaNode.getJSONObject("properties");
+        if (Objects.isNull(properties)) {
+            return;
+        }
+        for (final String key : properties.keySet()) {
+            if (obj.containsKey(key) && properties.get(key) instanceof final JSONObject childSchema) {
+                validateValue(obj.get(key), childSchema, "%s.%s".formatted(path, key), issues, checked);
+            }
+        }
+    }
+
+    /**
+     * 值类型是否匹配 Schema 类型声明（支持多类型数组）。
+     *
+     * @param value 实际值
+     * @param type  类型声明（String 或 JSONArray）
+     * @return boolean
+     */
+    private static boolean matchesType(final Object value, final Object type) {
+        if (type instanceof final String single) {
+            return matchesType(value, single);
+        }
+        if (type instanceof final JSONArray types) {
+            for (final Object item : types) {
+                if (matchesType(value, Convert.toStr(item))) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * 值类型是否匹配单个类型名。
+     *
+     * @param value 实际值
+     * @param type  类型名
+     * @return boolean
+     */
+    private static boolean matchesType(final Object value, final String type) {
+        return switch (type) {
+            case "object" -> value instanceof JSONObject;
+            case "array" -> value instanceof JSONArray;
+            case "string" -> value instanceof String;
+            case "boolean" -> value instanceof Boolean;
+            case "integer" -> value instanceof Integer || value instanceof Long;
+            case "number" -> value instanceof Number;
+            case "null" -> Objects.isNull(value);
+            // 未知类型声明不拦截
+            default -> true;
+        };
+    }
+
+    /**
+     * 实际值类型描述。
+     *
+     * @param value 实际值
+     * @return 类型描述
+     */
+    private static String actualType(final Object value) {
+        if (Objects.isNull(value)) {
+            return "null";
+        }
+        if (value instanceof JSONObject) {
+            return "object";
+        }
+        if (value instanceof JSONArray) {
+            return "array";
+        }
+        if (value instanceof Boolean) {
+            return "boolean";
+        }
+        if (value instanceof Integer || value instanceof Long) {
+            return "integer";
+        }
+        if (value instanceof Number) {
+            return "number";
+        }
+        return "string";
+    }
+
+    /**
+     * 转 BigDecimal（用于数值范围比较）。
+     *
+     * @param value 值
+     * @return BigDecimal；非数字返回 {@code null}
+     */
+    private static BigDecimal toBigDecimal(final Object value) {
+        return value instanceof final Number number ? BigDecimal.valueOf(number.doubleValue()) : null;
+    }
+}

--- a/src/main/java/com/acme/prism/ui/dialog/ConvertAnyDialog.java
+++ b/src/main/java/com/acme/prism/ui/dialog/ConvertAnyDialog.java
@@ -8,7 +8,6 @@ import com.acme.prism.common.enums.AnyFile;
 import com.acme.prism.common.enums.SupportedLanguages;
 import com.acme.prism.core.notice.Notifier;
 import com.acme.prism.core.parser.JsonParser;
-import com.acme.prism.ui.editor.CustomizeEditorFactory;
 import com.acme.prism.ui.editor.Editor;
 import com.alibaba.fastjson2.JSON;
 import com.alibaba.fastjson2.TypeReference;
@@ -312,8 +311,9 @@ public class ConvertAnyDialog extends DialogWrapper {
      * @return {@link EditorTextField }
      */
     private EditorTextField buildEditor(final AnyFile anyFile, final String converted) {
-        final EditorTextField field = new CustomizeEditorFactory(SupportedLanguages.getByAnyFile(anyFile), "Dummy.%s".formatted(anyFile.extension()))
-                .create(this.project);
+        // 统一复用编辑器创建入口
+        final EditorTextField field = Editor.createEditorField(
+                this.project, SupportedLanguages.getByAnyFile(anyFile), "Dummy.%s".formatted(anyFile.extension()));
         field.setText(converted);
         Editor.reformat(field);
         return field;

--- a/src/main/java/com/acme/prism/ui/dialog/CreateClassDialog.java
+++ b/src/main/java/com/acme/prism/ui/dialog/CreateClassDialog.java
@@ -2,18 +2,23 @@ package com.acme.prism.ui.dialog;
 
 import cn.hutool.core.util.StrUtil;
 import com.acme.prism.common.enums.AnyFile;
+import com.acme.prism.common.enums.SupportedLanguages;
 import com.acme.prism.core.json.JsonFormatter;
 import com.acme.prism.core.notice.Notifier;
 import com.acme.prism.core.parser.JsonParser;
 import com.acme.prism.core.parser.converter.JavaStructure;
+import com.acme.prism.ui.editor.Editor;
 import com.alibaba.fastjson2.JSON;
 import com.intellij.ide.highlighter.JavaFileType;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.command.WriteCommandAction;
+import com.intellij.openapi.editor.event.DocumentEvent;
+import com.intellij.openapi.editor.event.DocumentListener;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.progress.Task;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.ui.DialogWrapper;
 import com.intellij.openapi.ui.ValidationInfo;
 import com.intellij.psi.PsiDirectory;
@@ -21,8 +26,9 @@ import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiFileFactory;
 import com.intellij.psi.PsiJavaFile;
 import com.intellij.psi.codeStyle.CodeStyleManager;
+import com.intellij.ui.EditorTextField;
 import com.intellij.ui.components.JBRadioButton;
-import com.intellij.ui.components.JBTextArea;
+import com.intellij.ui.components.JBScrollPane;
 import com.intellij.ui.components.JBTextField;
 import com.intellij.util.concurrency.AppExecutorUtil;
 import com.intellij.util.ui.JBUI;
@@ -30,8 +36,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
-import javax.swing.event.DocumentEvent;
-import javax.swing.event.DocumentListener;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.io.Serial;
@@ -51,7 +55,10 @@ public class CreateClassDialog extends DialogWrapper {
     private static final ResourceBundle BUNDLE = ResourceBundle.getBundle("messages.PrismBundle");
 
     private final Project project;
-    private final JBTextArea jsonTextArea;
+    /**
+     * JSON 输入编辑器（JSON 语法高亮 + 行号）
+     */
+    private final EditorTextField jsonEditor;
     private final JBTextField classNameField;
     private final PsiDirectory targetDirectory;
     private final JBRadioButton classRadioButton;
@@ -68,20 +75,21 @@ public class CreateClassDialog extends DialogWrapper {
      */
     private static final int CLASS_NAME_FIELD_COLUMNS = 20;
     /**
-     * JSON 输入区行数
+     * 对话框初始宽度
      */
-    private static final int JSON_AREA_ROWS = 10;
+    private static final int DIALOG_WIDTH = 640;
     /**
-     * JSON 输入区列数
+     * 对话框初始高度
      */
-    private static final int JSON_AREA_COLUMNS = 40;
+    private static final int DIALOG_HEIGHT = 420;
 
     public CreateClassDialog(@Nullable final Project project, @NotNull final PsiDirectory targetDirectory) {
         super(project, Boolean.TRUE);
-        this.project = project;
+        // project 为空时兜底默认项目（仅用于编辑器文档创建，不涉及项目持久化）
+        this.project = Objects.requireNonNullElse(project, ProjectManager.getInstance().getDefaultProject());
         this.targetDirectory = targetDirectory;
         this.classNameField = new JBTextField(CLASS_NAME_FIELD_COLUMNS);
-        this.jsonTextArea = new JBTextArea(JSON_AREA_ROWS, JSON_AREA_COLUMNS);
+        this.jsonEditor = Editor.createEditorField(this.project, SupportedLanguages.JSON, "Dummy.json");
         this.classRadioButton = new JBRadioButton(BUNDLE.getString("create.class.type.class"), Boolean.TRUE);
         this.recordRadioButton = new JBRadioButton(BUNDLE.getString("create.class.type.record"), Boolean.FALSE);
         this.jsonFormatTimer = new Timer(FORMAT_DEBOUNCE_MS, _ -> this.scheduleJsonFormatting());
@@ -95,6 +103,7 @@ public class CreateClassDialog extends DialogWrapper {
         super.init();
         this.setModal(Boolean.FALSE);
         this.setResizable(Boolean.TRUE);
+        this.setSize(DIALOG_WIDTH, DIALOG_HEIGHT);
         this.setTitle(BUNDLE.getString("create.class.dialog.title"));
     }
 
@@ -175,48 +184,38 @@ public class CreateClassDialog extends DialogWrapper {
         if (!this.isValidClassName(this.getClassName())) {
             return new ValidationInfo(BUNDLE.getString("create.class.name.invalid"), this.classNameField);
         }
-        if (!JSON.isValid(this.jsonTextArea.getText())) {
-            return new ValidationInfo(BUNDLE.getString("create.class.json.invalid"), this.jsonTextArea);
+        if (!JSON.isValid(this.jsonEditor.getText())) {
+            return new ValidationInfo(BUNDLE.getString("create.class.json.invalid"), this.jsonEditor);
         }
         return null;
     }
 
     @Override
     protected @Nullable JComponent createCenterPanel() {
-        final JPanel dialogPanel = new JPanel(new GridBagLayout());
-        final GridBagConstraints gbc = new GridBagConstraints();
-        gbc.insets = JBUI.insets(5);
-        gbc.fill = GridBagConstraints.HORIZONTAL;
-
+        final JPanel panel = new JPanel(new BorderLayout(0, 10));
+        panel.setBorder(BorderFactory.createEmptyBorder(8, 8, 8, 8));
+        // 顶部：类型选择 + 类名输入
         final ButtonGroup typeGroup = new ButtonGroup();
         typeGroup.add(this.classRadioButton);
         typeGroup.add(this.recordRadioButton);
-
-        final JPanel radioPanel = new JPanel(new FlowLayout(FlowLayout.LEFT));
-        radioPanel.add(this.classRadioButton);
-        radioPanel.add(this.recordRadioButton);
-
-        gbc.gridx = 0;
-        gbc.gridy = 0;
-        dialogPanel.add(new JLabel(BUNDLE.getString("create.class.type.label")), gbc);
-
-        gbc.gridx = 1;
-        dialogPanel.add(radioPanel, gbc);
-
-        gbc.gridx = 0;
-        gbc.gridy = 1;
-        dialogPanel.add(new JLabel(BUNDLE.getString("create.class.name.label")), gbc);
-
-        gbc.gridx = 1;
-        dialogPanel.add(this.classNameField, gbc);
-
-        gbc.gridx = 0;
-        gbc.gridy = 2;
-        dialogPanel.add(new JLabel(BUNDLE.getString("create.class.json.label")), gbc);
-
-        gbc.gridx = 1;
-        dialogPanel.add(new JScrollPane(this.jsonTextArea), gbc);
-        return dialogPanel;
+        final JPanel typePanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 8, 0));
+        typePanel.add(new JLabel(BUNDLE.getString("create.class.type.label")));
+        typePanel.add(this.classRadioButton);
+        typePanel.add(this.recordRadioButton);
+        final JPanel namePanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 8, 0));
+        namePanel.add(new JLabel(BUNDLE.getString("create.class.name.label")));
+        this.classNameField.setPreferredSize(new Dimension(220, JBUI.scale(30)));
+        namePanel.add(this.classNameField);
+        final JPanel topPanel = new JPanel(new BorderLayout(0, 0));
+        topPanel.add(typePanel, BorderLayout.WEST);
+        topPanel.add(namePanel, BorderLayout.EAST);
+        panel.add(topPanel, BorderLayout.NORTH);
+        // 中部：JSON 输入编辑器（语法高亮 + 行号，占主体空间）
+        final JPanel jsonPanel = new JPanel(new BorderLayout(0, 4));
+        jsonPanel.add(new JLabel(BUNDLE.getString("create.class.json.label")), BorderLayout.NORTH);
+        jsonPanel.add(new JBScrollPane(this.jsonEditor), BorderLayout.CENTER);
+        panel.add(jsonPanel, BorderLayout.CENTER);
+        return panel;
     }
 
     private PsiFile addGeneratedClassToFile(final String classText) {
@@ -260,23 +259,13 @@ public class CreateClassDialog extends DialogWrapper {
     }
 
     public String getJsonText() {
-        return this.jsonTextArea.getText().trim();
+        return this.jsonEditor.getText().trim();
     }
 
     private void bindJsonFormattingListener() {
-        this.jsonTextArea.getDocument().addDocumentListener(new DocumentListener() {
+        this.jsonEditor.getDocument().addDocumentListener(new DocumentListener() {
             @Override
-            public void insertUpdate(final DocumentEvent e) {
-                CreateClassDialog.this.restartJsonFormatTimer();
-            }
-
-            @Override
-            public void removeUpdate(final DocumentEvent e) {
-                CreateClassDialog.this.restartJsonFormatTimer();
-            }
-
-            @Override
-            public void changedUpdate(final DocumentEvent e) {
+            public void documentChanged(final DocumentEvent e) {
                 CreateClassDialog.this.restartJsonFormatTimer();
             }
         });
@@ -294,7 +283,7 @@ public class CreateClassDialog extends DialogWrapper {
     }
 
     private void scheduleJsonFormatting() {
-        final String rawText = this.jsonTextArea.getText();
+        final String rawText = this.jsonEditor.getText();
         final long sequence = this.formatSequence.incrementAndGet();
         CompletableFuture
                 .supplyAsync(() -> JSON.isValid(rawText) ? new JsonFormatter().process(rawText) : null, AppExecutorUtil.getAppExecutorService())
@@ -302,12 +291,12 @@ public class CreateClassDialog extends DialogWrapper {
                     if (Objects.isNull(formattedJson) || sequence != this.formatSequence.get()) {
                         return;
                     }
-                    if (!StrUtil.equals(rawText, this.jsonTextArea.getText()) || StrUtil.equals(formattedJson, rawText)) {
+                    if (!StrUtil.equals(rawText, this.jsonEditor.getText()) || StrUtil.equals(formattedJson, rawText)) {
                         return;
                     }
                     this.applyingJsonFormat.set(Boolean.TRUE);
                     try {
-                        this.jsonTextArea.setText(formattedJson);
+                        this.jsonEditor.setText(formattedJson);
                     } finally {
                         this.applyingJsonFormat.set(Boolean.FALSE);
                     }

--- a/src/main/java/com/acme/prism/ui/dialog/JsonValidateDialog.java
+++ b/src/main/java/com/acme/prism/ui/dialog/JsonValidateDialog.java
@@ -1,0 +1,277 @@
+package com.acme.prism.ui.dialog;
+
+import cn.hutool.core.util.StrUtil;
+import com.acme.prism.common.enums.SupportedLanguages;
+import com.acme.prism.core.json.JsonSchemaGenerator;
+import com.acme.prism.core.json.JsonSchemaValidator;
+import com.acme.prism.core.json.JsonSchemaValidator.ValidationIssue;
+import com.acme.prism.core.json.JsonSchemaValidator.ValidationOutcome;
+import com.acme.prism.ui.editor.Editor;
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONObject;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.DialogWrapper;
+import com.intellij.ui.EditorTextField;
+import com.intellij.ui.components.JBScrollPane;
+import com.intellij.ui.table.JBTable;
+import com.intellij.util.concurrency.AppExecutorUtil;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+import javax.swing.table.DefaultTableModel;
+import java.awt.*;
+import java.util.List;
+import java.util.ResourceBundle;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * JSON Schema 校验对话框：JSON 数据对照 Schema 逐字段校验。
+ *
+ * <p>易用交互：目标 JSON 自动带入（只读预览）；Schema 自动识别（当前内容为 Schema 时直接填入），
+ * 或点「从当前 JSON 生成」一键生成；校验结果以表格展示失败项与汇总。</p>
+ *
+ * @author 拒绝者
+ * @date 2026-08-05
+ */
+public class JsonValidateDialog extends DialogWrapper {
+    /**
+     * 对话框初始宽度
+     */
+    private static final int DIALOG_WIDTH = 720;
+    /**
+     * 对话框初始高度
+     */
+    private static final int DIALOG_HEIGHT = 600;
+    /**
+     * 结果表格区高度（像素）
+     */
+    private static final int RESULT_TABLE_HEIGHT = 180;
+    /**
+     * 结果表格区最小高度（像素）
+     */
+    private static final int RESULT_TABLE_MIN_HEIGHT = 140;
+    /**
+     * 加载语言资源文件
+     */
+    private static final ResourceBundle BUNDLE = ResourceBundle.getBundle("messages.PrismBundle");
+    /**
+     * 编辑器项目
+     */
+    private final Project project;
+    /**
+     * 校验目标 JSON
+     */
+    private final String jsonText;
+    /**
+     * Schema 编辑器
+     */
+    private EditorTextField schemaEditor;
+    /**
+     * 结果汇总标签
+     */
+    private JLabel summaryLabel;
+    /**
+     * 结果表格
+     */
+    private JBTable resultTable;
+
+    public JsonValidateDialog(final Project project, final String jsonText) {
+        super(project, Boolean.TRUE);
+        this.project = project;
+        this.jsonText = jsonText;
+        this.init();
+    }
+
+    @Override
+    protected void init() {
+        super.init();
+        this.setModal(Boolean.FALSE);
+        this.setResizable(Boolean.TRUE);
+        this.setSize(DIALOG_WIDTH, DIALOG_HEIGHT);
+        this.setTitle(BUNDLE.getString("json.validate.title"));
+    }
+
+    @Override
+    protected JComponent createCenterPanel() {
+        final JPanel panel = new JPanel(new BorderLayout(0, 8));
+        panel.setBorder(BorderFactory.createEmptyBorder(8, 8, 8, 8));
+        panel.add(this.createTargetPanel(), BorderLayout.NORTH);
+        panel.add(this.createSchemaPanel(), BorderLayout.CENTER);
+        panel.add(this.createResultPanel(), BorderLayout.SOUTH);
+        return panel;
+    }
+
+    /**
+     * 创建校验目标 JSON 面板（只读预览）。
+     *
+     * @return 面板
+     */
+    private JComponent createTargetPanel() {
+        final JPanel panel = new JPanel(new BorderLayout(0, 4));
+        panel.add(new JLabel(BUNDLE.getString("json.validate.target")), BorderLayout.NORTH);
+        final EditorTextField viewer = this.createEditor(Boolean.FALSE);
+        viewer.setText(this.jsonText);
+        panel.add(new JBScrollPane(viewer), BorderLayout.CENTER);
+        return panel;
+    }
+
+    /**
+     * 创建 Schema 面板（可编辑 + 一键生成按钮）。
+     *
+     * @return 面板
+     */
+    private JComponent createSchemaPanel() {
+        final JPanel panel = new JPanel(new BorderLayout(0, 4));
+        final JPanel header = new JPanel(new BorderLayout());
+        header.add(new JLabel(BUNDLE.getString("json.validate.schema")), BorderLayout.WEST);
+        final JButton generateButton = new JButton(BUNDLE.getString("json.validate.generate.schema"));
+        generateButton.addActionListener(_ -> this.fillGeneratedSchema());
+        header.add(generateButton, BorderLayout.EAST);
+        panel.add(header, BorderLayout.NORTH);
+        this.schemaEditor = this.createEditor(Boolean.TRUE);
+        // Schema 自动识别：当前内容本身为 Schema 时直接填入
+        this.schemaEditor.setText(this.detectSchema());
+        panel.add(new JBScrollPane(this.schemaEditor), BorderLayout.CENTER);
+        return panel;
+    }
+
+    /**
+     * 创建结果面板（汇总 + 校验按钮 + 结果表格）。
+     *
+     * @return 面板
+     */
+    private JComponent createResultPanel() {
+        final JPanel panel = new JPanel(new BorderLayout(0, 4));
+        this.summaryLabel = new JLabel(" ");
+        final JButton validateButton = new JButton(BUNDLE.getString("json.validate.run"));
+        validateButton.addActionListener(_ -> this.runValidation());
+        final JPanel header = new JPanel(new BorderLayout());
+        header.add(this.summaryLabel, BorderLayout.CENTER);
+        header.add(validateButton, BorderLayout.EAST);
+        panel.add(header, BorderLayout.NORTH);
+        this.resultTable = new JBTable(new DefaultTableModel(
+                new Object[0][0],
+                new Object[]{BUNDLE.getString("json.validate.path"), BUNDLE.getString("json.validate.expected"),
+                        BUNDLE.getString("json.validate.actual"), BUNDLE.getString("json.validate.message")}
+        ));
+        this.resultTable.setFillsViewportHeight(Boolean.TRUE);
+        // 结果区固定最小高度，避免被 Schema 编辑器挤压
+        final JBScrollPane resultScroll = new JBScrollPane(this.resultTable);
+        resultScroll.setPreferredSize(new Dimension(0, RESULT_TABLE_HEIGHT));
+        resultScroll.setMinimumSize(new Dimension(0, RESULT_TABLE_MIN_HEIGHT));
+        panel.add(resultScroll, BorderLayout.CENTER);
+        return panel;
+    }
+
+    /**
+     * 创建 JSON 编辑器。
+     *
+     * @param editable 是否可编辑
+     * @return 编辑器
+     */
+    private EditorTextField createEditor(final boolean editable) {
+        // 统一复用编辑器创建入口
+        final EditorTextField field = Editor.createEditorField(this.project, SupportedLanguages.JSON, "Dummy.json");
+        // viewer 模式为只读（校验目标 JSON 预览）；非 viewer 可编辑（Schema 输入）
+        field.setViewer(!editable);
+        return field;
+    }
+
+    /**
+     * 识别当前内容是否为 Schema（顶层含 {@code $schema} 或 {@code properties}）。
+     *
+     * @return Schema 文本；非 Schema 返回空串
+     */
+    private String detectSchema() {
+        try {
+            final Object parsed = JSON.parse(this.jsonText);
+            if (parsed instanceof final JSONObject obj && (obj.containsKey("$schema") || obj.containsKey("properties"))) {
+                return this.jsonText;
+            }
+        } catch (final Exception ignored) {
+            // 非 Schema 内容，返回空串
+        }
+        return "";
+    }
+
+    /**
+     * 从当前 JSON 生成 Schema 并填入编辑器。
+     */
+    private void fillGeneratedSchema() {
+        final AtomicReference<String> generated = new AtomicReference<>();
+        CompletableFuture
+                .supplyAsync(() -> new JsonSchemaGenerator().process(this.jsonText), AppExecutorUtil.getAppExecutorService())
+                .thenAccept(schema -> ApplicationManager.getApplication().invokeLater(() -> {
+                    if (StrUtil.isBlank(schema)) {
+                        return;
+                    }
+                    this.schemaEditor.setText(schema);
+                }));
+    }
+
+    /**
+     * 执行校验并更新结果（后台线程计算，避免大 JSON 阻塞 EDT）。
+     */
+    private void runValidation() {
+        final String schemaText = this.schemaEditor.getText();
+        if (StrUtil.isBlank(schemaText)) {
+            this.summaryLabel.setText(BUNDLE.getString("json.validate.schema.empty"));
+            return;
+        }
+        CompletableFuture
+                .supplyAsync(() -> JsonSchemaValidator.validate(this.jsonText, schemaText), AppExecutorUtil.getAppExecutorService())
+                .thenAccept(outcome -> ApplicationManager.getApplication().invokeLater(() -> this.renderResult(outcome)))
+                .exceptionally(error -> {
+                    ApplicationManager.getApplication().invokeLater(() ->
+                            this.summaryLabel.setText(BUNDLE.getString("json.validate.failed").formatted(error.getMessage())));
+                    return null;
+                });
+    }
+
+    /**
+     * 渲染校验结果。
+     *
+     * @param outcome 校验结果
+     */
+    private void renderResult(final ValidationOutcome outcome) {
+        if (outcome.issues().isEmpty()) {
+            this.summaryLabel.setText(BUNDLE.getString("json.validate.pass").formatted(outcome.checkedCount()));
+            // 通过时表格空状态提示（替换默认 Nothing to show）
+            this.resultTable.getEmptyText().setText(BUNDLE.getString("json.validate.result.empty"));
+        } else {
+            this.summaryLabel.setText(BUNDLE.getString("json.validate.fail.summary")
+                    .formatted(outcome.checkedCount(), outcome.issues().size()));
+            this.resultTable.getEmptyText().setText("");
+        }
+        this.resultTable.setModel(this.createResultModel(outcome.issues()));
+    }
+
+    /**
+     * 构建结果表格模型。
+     *
+     * @param issues 失败项
+     * @return 表格模型
+     */
+    private DefaultTableModel createResultModel(final List<ValidationIssue> issues) {
+        final Object[][] rows = issues.stream()
+                .map(issue -> new Object[]{issue.path(), issue.expected(), issue.actual(), issue.message()})
+                .toArray(Object[][]::new);
+        return new DefaultTableModel(rows, new Object[]{
+                BUNDLE.getString("json.validate.path"), BUNDLE.getString("json.validate.expected"),
+                BUNDLE.getString("json.validate.actual"), BUNDLE.getString("json.validate.message")
+        });
+    }
+
+    @Override
+    protected Action @NotNull [] createActions() {
+        // 移除默认按钮，校验按钮在面板内
+        return new Action[0];
+    }
+
+    @Override
+    protected JComponent createSouthPanel() {
+        return null;
+    }
+}

--- a/src/main/java/com/acme/prism/ui/editor/Editor.java
+++ b/src/main/java/com/acme/prism/ui/editor/Editor.java
@@ -1,5 +1,6 @@
 package com.acme.prism.ui.editor;
 
+import com.acme.prism.common.enums.SupportedLanguages;
 import com.acme.prism.core.editor.FileDropHandler;
 import com.intellij.openapi.actionSystem.IdeActions;
 import com.intellij.openapi.application.ApplicationManager;
@@ -37,6 +38,20 @@ public interface Editor {
      */
     default EditorTextField create(final Project project) {
         return new EditorTextField();
+    }
+
+    /**
+     * 统一创建带语言高亮的编辑器字段（JSON 语言自动注入 null 独立着色）。
+     *
+     * <p>各对话框复用此入口，避免 {@code new CustomizeEditorFactory(...)} 散落多处。</p>
+     *
+     * @param project  项目
+     * @param language 语言
+     * @param fileName 虚拟文件名（用于语言高亮识别）
+     * @return {@link EditorTextField }
+     */
+    static EditorTextField createEditorField(final Project project, final SupportedLanguages language, final String fileName) {
+        return new CustomizeEditorFactory(language, fileName).create(project);
     }
 
     /**

--- a/src/main/java/com/acme/prism/ui/panel/MainPanel.java
+++ b/src/main/java/com/acme/prism/ui/panel/MainPanel.java
@@ -9,6 +9,7 @@ import com.acme.prism.core.parser.JwtParser;
 import com.acme.prism.core.parser.PathParser;
 import com.acme.prism.ui.dialog.ConvertAnyDialog;
 import com.acme.prism.ui.dialog.JsonAnalyzeDialog;
+import com.acme.prism.ui.dialog.JsonValidateDialog;
 import com.acme.prism.ui.editor.JsonFoldingSupport;
 import com.alibaba.fastjson2.JSON;
 import com.intellij.diff.DiffContentFactory;
@@ -202,6 +203,8 @@ public class MainPanel {
                 _ -> this.optJson(redoButton, undoButton, editor.getEditor(), new JsonSchemaGenerator())));
         panel.add(this.createToolButton(BUNDLE.getString("json.mock.generate"), AllIcons.Actions.Rerun,
                 _ -> this.optJson(redoButton, undoButton, editor.getEditor(), new JsonMockGenerator())));
+        panel.add(this.createToolButton(BUNDLE.getString("json.validate"), AllIcons.General.GreenCheckmark,
+                _ -> this.showValidateDialog(editor)));
         panel.add(this.createToolButton(BUNDLE.getString("json.analyze"), AllIcons.Actions.Find,
                 _ -> this.showAnalyzeDialog(editor)));
         return panel;
@@ -319,6 +322,18 @@ public class MainPanel {
         final String text = editor.getText();
         if (StrUtil.isBlank(text)) return;
         ApplicationManager.getApplication().invokeLater(() -> new JsonAnalyzeDialog(editor.getProject(), text).show());
+    }
+
+    /**
+     * 展示 JSON Schema 校验弹窗。
+     *
+     * @param editor 当前编辑
+     */
+    private void showValidateDialog(final EditorTextField editor) {
+        if (Objects.isNull(editor) || Objects.isNull(editor.getProject())) return;
+        final String text = editor.getText();
+        if (StrUtil.isBlank(text)) return;
+        ApplicationManager.getApplication().invokeLater(() -> new JsonValidateDialog(editor.getProject(), text).show());
     }
 
     /**

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -5,13 +5,14 @@
 
     <!-- 插件描述：patchPluginXml 不会覆盖（build.gradle 未设置 description） -->
     <description><![CDATA[
-        Prism is an IntelliJ IDEA plugin that pairs JSON tooling (edit, repair, query, convert,
-        Java class generation, JsonPath, multi-format export) with editor enhancements:
+        Prism is an IntelliJ IDEA plugin that pairs JSON tooling (edit, repair, analyze, validate against JSON Schema,
+        sort, flatten/unflatten, mock data generation, query, convert to XML/CSV/YAML/SQL, Java class generation,
+        JsonPath, multi-format export) with editor enhancements:
         code minimap with git and inspection stripes, rainbow highlights, project tree insights,
         archive browsing, code screenshots, and project/HTTP/port search.
         <div style="max-width: 600px; margin: 0 auto; padding: 10px;">
             <a href="https://github.com/fc6a1b03/prism" style="color: #2B65EC; text-decoration: none; font-weight: 500;">Github</a>
-            <p style="color: #666; line-height: 1.5; margin: 8px 0 12px;">Prism 集 JSON 工具与编辑器增强于一身：自由编辑/修复/查询/转换 JSON、Java 类互转、多格式导出；并提供代码地图（Git 与异味标记）、彩虹括号与变量高亮、颜色字面量、项目树文件注释与压缩包浏览、代码截图、项目/HTTP/端口搜索等能力</p>
+            <p style="color: #666; line-height: 1.5; margin: 8px 0 12px;">Prism 集 JSON 工具与编辑器增强于一身：自由编辑/修复/分析/Schema 校验/排序/压平/还原/Mock 数据生成/查询/转换 JSON、Java 类互转、多格式导出；并提供代码地图（Git 与异味标记）、彩虹括号与变量高亮、颜色字面量、项目树文件注释与压缩包浏览、代码截图、项目/HTTP/端口搜索等能力</p>
         </div>
     ]]></description>
 

--- a/src/main/resources/messages/PrismBundle.properties
+++ b/src/main/resources/messages/PrismBundle.properties
@@ -147,3 +147,20 @@ json.repair.low.confidence=Low repair confidence, please verify the result manua
 
 json.mock.generate=Generate Mock Data
 json.mock.generate.desc=Generate random test data from JSON sample
+
+json.validate=Validate Schema
+json.validate.title=JSON Schema Validation
+json.validate.target=Target JSON
+json.validate.schema=Schema
+json.validate.generate.schema=Generate Schema from JSON
+json.validate.run=Validate
+json.validate.path=Path
+json.validate.expected=Expected
+json.validate.actual=Actual
+json.validate.message=Message
+json.validate.pass=Validation passed (%d items checked)
+json.validate.fail.summary=%d items checked, %d failed
+json.validate.schema.empty=Please provide a Schema first (or click Generate Schema from JSON)
+json.validate.failed=Validation failed: %s
+
+json.validate.result.empty=Validation passed, no failures

--- a/src/main/resources/messages/PrismBundle_zh_CN.properties
+++ b/src/main/resources/messages/PrismBundle_zh_CN.properties
@@ -147,3 +147,20 @@ json.repair.low.confidence=修复置信度较低，请人工核对结果
 
 json.mock.generate=生成 Mock 数据
 json.mock.generate.desc=按样例 JSON 结构生成随机测试数据
+
+json.validate=校验 Schema
+json.validate.title=JSON Schema 校验
+json.validate.target=校验目标 JSON
+json.validate.schema=校验 Schema
+json.validate.generate.schema=从当前 JSON 生成 Schema
+json.validate.run=开始校验
+json.validate.path=路径
+json.validate.expected=期望
+json.validate.actual=实际
+json.validate.message=说明
+json.validate.pass=校验通过（共校验 %d 项）
+json.validate.fail.summary=共校验 %d 项，失败 %d 项
+json.validate.schema.empty=请先填写 Schema（可点「从当前 JSON 生成」）
+json.validate.failed=校验失败：%s
+
+json.validate.result.empty=校验通过，无失败项

--- a/src/test/java/com/acme/prism/core/json/JsonSchemaValidatorTest.java
+++ b/src/test/java/com/acme/prism/core/json/JsonSchemaValidatorTest.java
@@ -1,0 +1,145 @@
+package com.acme.prism.core.json;
+
+import com.acme.prism.core.json.JsonSchemaValidator.ValidationOutcome;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * JSON Schema 校验器单元测试
+ *
+ * @author 拒绝者
+ * @date 2026-08-05
+ */
+class JsonSchemaValidatorTest {
+
+    @Test
+    @DisplayName("正常：类型匹配校验通过")
+    void passesTypeMatch() {
+        final ValidationOutcome outcome = JsonSchemaValidator.validate(
+                "{\"name\":\"x\",\"age\":18}",
+                "{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"age\":{\"type\":\"integer\"}}}"
+        );
+        assertTrue(outcome.issues().isEmpty(), "类型匹配应校验通过");
+        assertTrue(outcome.checkedCount() > 0);
+    }
+
+    @Test
+    @DisplayName("异常：类型不匹配被检出")
+    void detectsTypeMismatch() {
+        final ValidationOutcome outcome = JsonSchemaValidator.validate(
+                "{\"age\":\"18\"}",
+                "{\"type\":\"object\",\"properties\":{\"age\":{\"type\":\"integer\"}}}"
+        );
+        assertEquals(1, outcome.issues().size());
+        assertEquals("$.age", outcome.issues().getFirst().path());
+    }
+
+    @Test
+    @DisplayName("异常：缺少必填字段被检出")
+    void detectsMissingRequired() {
+        final ValidationOutcome outcome = JsonSchemaValidator.validate(
+                "{\"name\":\"x\"}",
+                "{\"type\":\"object\",\"required\":[\"name\",\"age\"]}"
+        );
+        assertTrue(outcome.issues().stream().anyMatch(issue -> issue.message().contains("age")),
+                "应检出缺失的必填字段 age");
+    }
+
+    @Test
+    @DisplayName("正常：嵌套对象递归校验")
+    void validatesNestedObjects() {
+        final ValidationOutcome outcome = JsonSchemaValidator.validate(
+                "{\"user\":{\"name\":\"x\"}}",
+                "{\"type\":\"object\",\"properties\":{\"user\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"number\"}}}}}"
+        );
+        assertEquals(1, outcome.issues().size());
+        assertEquals("$.user.name", outcome.issues().getFirst().path());
+    }
+
+    @Test
+    @DisplayName("正常：数组元素校验")
+    void validatesArrayItems() {
+        final ValidationOutcome outcome = JsonSchemaValidator.validate(
+                "{\"list\":[1,\"a\"]}",
+                "{\"type\":\"object\",\"properties\":{\"list\":{\"type\":\"array\",\"items\":{\"type\":\"integer\"}}}}"
+        );
+        assertEquals(1, outcome.issues().size(), "数组中字符串元素应检出类型不匹配");
+        assertEquals("$.list[1]", outcome.issues().getFirst().path());
+    }
+
+    @Test
+    @DisplayName("正常：枚举校验")
+    void validatesEnum() {
+        final ValidationOutcome outcome = JsonSchemaValidator.validate(
+                "{\"status\":\"unknown\"}",
+                "{\"type\":\"object\",\"properties\":{\"status\":{\"enum\":[\"active\",\"disabled\"]}}}"
+        );
+        assertTrue(outcome.issues().stream().anyMatch(issue -> issue.message().contains("枚举")),
+                "不在枚举范围的值应被检出");
+    }
+
+    @Test
+    @DisplayName("正常：字符串长度约束")
+    void validatesStringLength() {
+        final ValidationOutcome outcome = JsonSchemaValidator.validate(
+                "{\"code\":\"abc\"}",
+                "{\"type\":\"object\",\"properties\":{\"code\":{\"type\":\"string\",\"minLength\":5}}}"
+        );
+        assertTrue(outcome.issues().stream().anyMatch(issue -> issue.message().contains("过短")));
+    }
+
+    @Test
+    @DisplayName("正常：数值范围约束")
+    void validatesNumberRange() {
+        final ValidationOutcome outcome = JsonSchemaValidator.validate(
+                "{\"score\":150}",
+                "{\"type\":\"object\",\"properties\":{\"score\":{\"type\":\"number\",\"maximum\":100}}}"
+        );
+        assertTrue(outcome.issues().stream().anyMatch(issue -> issue.message().contains("大于最大值")));
+    }
+
+    @Test
+    @DisplayName("正常：正则匹配约束")
+    void validatesPattern() {
+        final ValidationOutcome outcome = JsonSchemaValidator.validate(
+                "{\"email\":\"not-an-email\"}",
+                "{\"type\":\"object\",\"properties\":{\"email\":{\"type\":\"string\",\"pattern\":\"^\\\\w+@\\\\w+\\\\.\\\\w+$\"}}}"
+        );
+        assertTrue(outcome.issues().stream().anyMatch(issue -> issue.message().contains("正则")));
+    }
+
+    @Test
+    @DisplayName("正常：多类型声明任一匹配即通过")
+    void supportsMultiType() {
+        final ValidationOutcome outcome = JsonSchemaValidator.validate(
+                "{\"value\":\"x\"}",
+                "{\"type\":\"object\",\"properties\":{\"value\":{\"type\":[\"string\",\"number\"]}}}"
+        );
+        assertTrue(outcome.issues().isEmpty(), "多类型中任一匹配应通过");
+    }
+
+    @Test
+    @DisplayName("异常：JSON 或 Schema 解析失败返回解析失败项")
+    void reportsParseFailure() {
+        final ValidationOutcome outcome = JsonSchemaValidator.validate("not json", "{}");
+        assertFalse(outcome.issues().isEmpty());
+        assertTrue(outcome.issues().getFirst().message().contains("解析"));
+    }
+
+    @Test
+    @DisplayName("边界：空输入返回空结果")
+    void handlesBlankInput() {
+        assertTrue(JsonSchemaValidator.validate("", "{}").issues().isEmpty());
+        assertTrue(JsonSchemaValidator.validate(null, "{}").issues().isEmpty());
+    }
+
+    @Test
+    @DisplayName("异常：Schema 非对象被检出")
+    void rejectsNonObjectSchema() {
+        final ValidationOutcome outcome = JsonSchemaValidator.validate("{\"a\":1}", "[]");
+        assertFalse(outcome.issues().isEmpty());
+        assertTrue(outcome.issues().getFirst().message().contains("Schema"));
+    }
+}


### PR DESCRIPTION
- 新增 JsonSchemaValidator：JSON 对照 Schema 逐字段校验（type/required/enum/数值范围/items/pattern），输出失败项路径与汇总
- 新增 JsonValidateDialog：目标 JSON 自动带入、Schema 自动识别或从当前 JSON 一键生成、失败项表格展示与中文空状态
- 工具条新增校验按钮（GreenCheckmark）；校验结果区高度修复
- CreateClassDialog 升级：JSON 输入改语法高亮编辑器（EditorTextField），布局重构（类型/类名一行 + 编辑区占主体）
- 编辑器创建统一收敛至 Editor.createEditorField（转换/校验/建类对话框复用，消除 CustomizeEditorFactory 散落）
- plugin.xml 描述补充 analyze/schema/mock/SQL 关键词（中英同步）
- 新增 13 个单元测试（总 474 全绿），i18n 161 键双文件一致