### PR TITLE
feat: Schema 校验器补全 format/组合/数组约束，发布 0.20.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,11 @@ intellijPlatform {
         version = project.version.toString()
         // sinceBuild 自 IGP 2.14 起默认取目标平台 major build（2026.2 → 262），无需显式声明
         changeNotes = """
+            <b>0.20.6</b>
+            <ul>
+                <li>Schema 校验器补全关键字：format（email/date-time/date/time/uri/uuid/ipv4/ipv6）、oneOf/anyOf/allOf 组合约束、minItems/maxItems/uniqueItems、minProperties/maxProperties、exclusiveMinimum/exclusiveMaximum、multipleOf。</li>
+                <li>组合约束独立校验（不污染主失败项与计数），正则预编译，时间格式用 java.time 解析。</li>
+            </ul>
             <b>0.20.5</b>
             <ul>
                 <li>JSON Schema 校验：新增 JsonSchemaValidator（type/required/enum/范围/items/pattern 逐字段校验）与校验弹窗（目标 JSON 自动带入、Schema 自动识别或一键生成、失败项表格展示），工具条新增校验按钮。</li>

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 // 统一版本表：插件版本、目标平台、Java 基线与第三方依赖版本在此集中维护
 gradle.ext.versions = [
         // 插件版本：发布新版本时递增，并同步更新 build.gradle 中的 changeNotes
-        ver         : "0.20.5",
+        ver         : "0.20.6",
         // 目标 IntelliJ 平台版本：sinceBuild 自 IGP 2.14 起默认取平台 major build（2026.2 → 262），无需显式声明
         idea        : "2026.2",
         // Java 语言基线：toolchain 与 options.release 共用

--- a/src/main/java/com/acme/prism/core/json/JsonSchemaValidator.java
+++ b/src/main/java/com/acme/prism/core/json/JsonSchemaValidator.java
@@ -7,9 +7,17 @@ import com.alibaba.fastjson2.JSONArray;
 import com.alibaba.fastjson2.JSONObject;
 
 import java.math.BigDecimal;
+import java.net.URI;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
@@ -17,14 +25,33 @@ import java.util.regex.PatternSyntaxException;
 /**
  * JSON Schema 校验器：按 JSON Schema（Draft 7 常用关键字）逐字段校验 JSON 数据。
  *
- * <p>支持关键字：type（含多类型数组）、required、properties、items、enum、
- * minLength/maxLength、minimum/maximum、pattern。输出每个失败项（路径/期望/实际/说明）
+ * <p>支持关键字：type（含多类型数组）、required、properties、items、enum、minLength/maxLength、
+ * minimum/maximum、pattern、format（email/date-time/date/time/uri/uuid/ipv4/ipv6）、
+ * oneOf/anyOf/allOf、minItems/maxItems/uniqueItems、minProperties/maxProperties、
+ * exclusiveMinimum/exclusiveMaximum、multipleOf。输出每个失败项（路径/期望/实际/说明）
  * 与已校验字段总数。</p>
  *
  * @author 拒绝者
  * @date 2026-08-05
  */
 public final class JsonSchemaValidator {
+
+    /**
+     * email 格式正则
+     */
+    private static final Pattern EMAIL_PATTERN = Pattern.compile("^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$");
+    /**
+     * uuid 格式正则
+     */
+    private static final Pattern UUID_PATTERN = Pattern.compile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$");
+    /**
+     * ipv4 格式正则
+     */
+    private static final Pattern IPV4_PATTERN = Pattern.compile("^((25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)\\.){3}(25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)$");
+    /**
+     * ipv6 格式正则（覆盖常见书写，非完整 RFC 4291）
+     */
+    private static final Pattern IPV6_PATTERN = Pattern.compile("^([0-9a-fA-F]{0,4}:){2,7}[0-9a-fA-F]{0,4}$");
 
     /**
      * 校验失败项。
@@ -103,26 +130,23 @@ public final class JsonSchemaValidator {
         if (Objects.nonNull(enumValues) && !enumValues.contains(value)) {
             issues.add(new ValidationIssue(path, "枚举值之一", String.valueOf(value), "不在枚举范围内"));
         }
-        // 3. 字符串约束
+        // 3. 组合约束校验（oneOf 恰好一个 / anyOf 至少一个 / allOf 全部满足）
+        validateCombinators(value, schemaNode, path, issues);
+        // 4. 字符串约束
         if (value instanceof final String text) {
             validateString(text, schemaNode, path, issues);
         }
-        // 4. 数字约束
+        // 5. 数字约束
         if (value instanceof final Number number) {
             validateNumber(number, schemaNode, path, issues);
         }
-        // 5. 对象：必填字段 + 子属性递归
+        // 6. 对象：必填字段 + 属性数量 + 子属性递归
         if (value instanceof final JSONObject obj) {
             validateObject(obj, schemaNode, path, issues, checked);
         }
-        // 6. 数组：元素递归
+        // 7. 数组：长度约束 + 元素唯一 + 元素递归
         if (value instanceof final JSONArray arr) {
-            final Object items = schemaNode.get("items");
-            if (items instanceof final JSONObject itemSchema) {
-                for (int index = 0; index < arr.size(); index++) {
-                    validateValue(arr.get(index), itemSchema, "%s[%d]".formatted(path, index), issues, checked);
-                }
-            }
+            validateArray(arr, schemaNode, path, issues, checked);
         }
     }
 
@@ -154,6 +178,75 @@ public final class JsonSchemaValidator {
                 // Schema 中非法正则忽略，不中断校验
             }
         }
+        final String format = schemaNode.getString("format");
+        if (StrUtil.isNotBlank(format)) {
+            validateFormat(text, format, path, issues);
+        }
+    }
+
+    /**
+     * 校验字符串格式约束（未知 format 不拦截，符合 Draft 7 语义）。
+     *
+     * @param text   字符串
+     * @param format 格式名
+     * @param path   路径
+     * @param issues 失败项收集器
+     */
+    private static void validateFormat(final String text, final String format, final String path,
+                                       final List<ValidationIssue> issues) {
+        final boolean valid = switch (format) {
+            case "email" -> EMAIL_PATTERN.matcher(text).matches();
+            case "uuid" -> UUID_PATTERN.matcher(text).matches();
+            case "ipv4" -> IPV4_PATTERN.matcher(text).matches();
+            case "ipv6" -> IPV6_PATTERN.matcher(text).matches();
+            case "date" -> isParseable(text, LocalDate.class);
+            case "time" -> isParseable(text, LocalTime.class);
+            case "date-time" -> isParseable(text, OffsetDateTime.class) || isParseable(text, Instant.class);
+            case "uri" -> isUri(text);
+            default -> Boolean.TRUE;
+        };
+        if (!valid) {
+            issues.add(new ValidationIssue(path, "格式 " + format, text, "不符合格式要求"));
+        }
+    }
+
+    /**
+     * 尝试按类型解析时间文本。
+     *
+     * @param text      文本
+     * @param timeClass 时间类型
+     * @return boolean
+     */
+    private static boolean isParseable(final String text, final Class<?> timeClass) {
+        try {
+            if (timeClass == LocalDate.class) {
+                LocalDate.parse(text);
+            } else if (timeClass == LocalTime.class) {
+                LocalTime.parse(text);
+            } else if (timeClass == OffsetDateTime.class) {
+                OffsetDateTime.parse(text);
+            } else {
+                Instant.parse(text);
+            }
+            return Boolean.TRUE;
+        } catch (final DateTimeParseException ignored) {
+            return Boolean.FALSE;
+        }
+    }
+
+    /**
+     * 校验是否为合法 URI（需含 scheme）。
+     *
+     * @param text 文本
+     * @return boolean
+     */
+    private static boolean isUri(final String text) {
+        try {
+            final URI uri = URI.create(text);
+            return StrUtil.isNotBlank(uri.getScheme());
+        } catch (final IllegalArgumentException ignored) {
+            return Boolean.FALSE;
+        }
     }
 
     /**
@@ -175,6 +268,19 @@ public final class JsonSchemaValidator {
         if (Objects.nonNull(maximum) && value.compareTo(maximum) > 0) {
             issues.add(new ValidationIssue(path, "≤ " + maximum.toPlainString(), String.valueOf(number), "大于最大值"));
         }
+        final BigDecimal exclusiveMinimum = toBigDecimal(schemaNode.get("exclusiveMinimum"));
+        if (Objects.nonNull(exclusiveMinimum) && value.compareTo(exclusiveMinimum) <= 0) {
+            issues.add(new ValidationIssue(path, "> " + exclusiveMinimum.toPlainString(), String.valueOf(number), "不大于排他最小值"));
+        }
+        final BigDecimal exclusiveMaximum = toBigDecimal(schemaNode.get("exclusiveMaximum"));
+        if (Objects.nonNull(exclusiveMaximum) && value.compareTo(exclusiveMaximum) >= 0) {
+            issues.add(new ValidationIssue(path, "< " + exclusiveMaximum.toPlainString(), String.valueOf(number), "不小于排他最大值"));
+        }
+        final BigDecimal multipleOf = toBigDecimal(schemaNode.get("multipleOf"));
+        if (Objects.nonNull(multipleOf) && multipleOf.compareTo(BigDecimal.ZERO) > 0
+                && value.remainder(multipleOf).compareTo(BigDecimal.ZERO) != 0) {
+            issues.add(new ValidationIssue(path, "是 " + multipleOf.toPlainString() + " 的倍数", String.valueOf(number), "不是倍数"));
+        }
     }
 
     /**
@@ -188,6 +294,14 @@ public final class JsonSchemaValidator {
      */
     private static void validateObject(final JSONObject obj, final JSONObject schemaNode, final String path,
                                        final List<ValidationIssue> issues, final AtomicInteger checked) {
+        final Integer minProperties = schemaNode.getInteger("minProperties");
+        if (Objects.nonNull(minProperties) && obj.size() < minProperties) {
+            issues.add(new ValidationIssue(path, "属性数 ≥ %d".formatted(minProperties), String.valueOf(obj.size()), "对象属性过少"));
+        }
+        final Integer maxProperties = schemaNode.getInteger("maxProperties");
+        if (Objects.nonNull(maxProperties) && obj.size() > maxProperties) {
+            issues.add(new ValidationIssue(path, "属性数 ≤ %d".formatted(maxProperties), String.valueOf(obj.size()), "对象属性过多"));
+        }
         final JSONArray required = schemaNode.getJSONArray("required");
         if (Objects.nonNull(required)) {
             for (final Object item : required) {
@@ -206,6 +320,103 @@ public final class JsonSchemaValidator {
                 validateValue(obj.get(key), childSchema, "%s.%s".formatted(path, key), issues, checked);
             }
         }
+    }
+
+    /**
+     * 校验数组：长度约束 + 元素唯一 + 元素递归。
+     *
+     * @param arr        数组
+     * @param schemaNode Schema 节点
+     * @param path       路径
+     * @param issues     失败项收集器
+     * @param checked    已校验计数
+     */
+    private static void validateArray(final JSONArray arr, final JSONObject schemaNode, final String path,
+                                      final List<ValidationIssue> issues, final AtomicInteger checked) {
+        final Integer minItems = schemaNode.getInteger("minItems");
+        if (Objects.nonNull(minItems) && arr.size() < minItems) {
+            issues.add(new ValidationIssue(path, "长度 ≥ %d".formatted(minItems), String.valueOf(arr.size()), "数组元素过少"));
+        }
+        final Integer maxItems = schemaNode.getInteger("maxItems");
+        if (Objects.nonNull(maxItems) && arr.size() > maxItems) {
+            issues.add(new ValidationIssue(path, "长度 ≤ %d".formatted(maxItems), String.valueOf(arr.size()), "数组元素过多"));
+        }
+        final Boolean uniqueItems = schemaNode.getBoolean("uniqueItems");
+        if (Boolean.TRUE.equals(uniqueItems) && hasDuplicates(arr)) {
+            issues.add(new ValidationIssue(path, "元素唯一", String.valueOf(arr.size()) + " 个元素", "数组存在重复元素"));
+        }
+        final Object items = schemaNode.get("items");
+        if (items instanceof final JSONObject itemSchema) {
+            for (int index = 0; index < arr.size(); index++) {
+                validateValue(arr.get(index), itemSchema, "%s[%d]".formatted(path, index), issues, checked);
+            }
+        }
+    }
+
+    /**
+     * 数组元素是否含重复（JSON 值按字符串化比较）。
+     *
+     * @param arr 数组
+     * @return boolean
+     */
+    private static boolean hasDuplicates(final JSONArray arr) {
+        final Set<String> seen = new HashSet<>(arr.size());
+        for (final Object item : arr) {
+            if (!seen.add(JSON.toJSONString(item))) {
+                return Boolean.TRUE;
+            }
+        }
+        return Boolean.FALSE;
+    }
+
+    /**
+     * 校验组合约束（oneOf 恰好一个 / anyOf 至少一个 / allOf 全部满足）。
+     *
+     * @param value      实际值
+     * @param schemaNode Schema 节点
+     * @param path       路径
+     * @param issues     失败项收集器
+     */
+    private static void validateCombinators(final Object value, final JSONObject schemaNode, final String path,
+                                            final List<ValidationIssue> issues) {
+        final JSONArray oneOf = schemaNode.getJSONArray("oneOf");
+        if (Objects.nonNull(oneOf)) {
+            final long matched = countMatches(value, oneOf, path);
+            if (matched != 1) {
+                issues.add(new ValidationIssue(path, "恰好匹配一个子约束", "匹配 " + matched + " 个", "oneOf 约束不满足"));
+            }
+        }
+        final JSONArray anyOf = schemaNode.getJSONArray("anyOf");
+        if (Objects.nonNull(anyOf) && countMatches(value, anyOf, path) == 0) {
+            issues.add(new ValidationIssue(path, "至少匹配一个子约束", "匹配 0 个", "anyOf 约束不满足"));
+        }
+        final JSONArray allOf = schemaNode.getJSONArray("allOf");
+        if (Objects.nonNull(allOf)) {
+            final long matched = countMatches(value, allOf, path);
+            if (matched != allOf.size()) {
+                issues.add(new ValidationIssue(path, "满足全部 " + allOf.size() + " 个子约束", "满足 " + matched + " 个", "allOf 约束不满足"));
+            }
+        }
+    }
+
+    /**
+     * 统计值与子约束列表匹配的数量（独立校验，不污染主失败项与计数）。
+     *
+     * @param value      实际值
+     * @param schemas    子约束列表
+     * @param path       路径
+     * @return 匹配数量
+     */
+    private static long countMatches(final Object value, final JSONArray schemas, final String path) {
+        return schemas.stream()
+                .filter(JSONObject.class::isInstance)
+                .map(JSONObject.class::cast)
+                .filter(subSchema -> {
+                    final List<ValidationIssue> temp = new ArrayList<>();
+                    validateValue(value, subSchema, path, temp, new AtomicInteger());
+                    return temp.isEmpty();
+                })
+                .count();
     }
 
     /**

--- a/src/test/java/com/acme/prism/core/json/JsonSchemaValidatorTest.java
+++ b/src/test/java/com/acme/prism/core/json/JsonSchemaValidatorTest.java
@@ -142,4 +142,107 @@ class JsonSchemaValidatorTest {
         assertFalse(outcome.issues().isEmpty());
         assertTrue(outcome.issues().getFirst().message().contains("Schema"));
     }
+
+    @Test
+    @DisplayName("正常：format 校验 email 与 date-time")
+    void validatesFormat() {
+        final ValidationOutcome ok = JsonSchemaValidator.validate(
+                "{\"email\":\"a@b.com\",\"time\":\"2026-01-01T10:00:00Z\"}",
+                "{\"type\":\"object\",\"properties\":{\"email\":{\"type\":\"string\",\"format\":\"email\"}," +
+                        "\"time\":{\"type\":\"string\",\"format\":\"date-time\"}}}"
+        );
+        assertTrue(ok.issues().isEmpty(), "合法 email 与日期应通过");
+
+        final ValidationOutcome bad = JsonSchemaValidator.validate(
+                "{\"email\":\"not-an-email\",\"time\":\"yesterday\"}",
+                "{\"type\":\"object\",\"properties\":{\"email\":{\"type\":\"string\",\"format\":\"email\"}," +
+                        "\"time\":{\"type\":\"string\",\"format\":\"date-time\"}}}"
+        );
+        assertEquals(2, bad.issues().size(), "非法 email 与日期应各报一项");
+    }
+
+    @Test
+    @DisplayName("正常：format 校验 uri 与 ipv4")
+    void validatesUriAndIpv4() {
+        final ValidationOutcome ok = JsonSchemaValidator.validate(
+                "{\"url\":\"https://example.com\",\"ip\":\"192.168.1.1\"}",
+                "{\"type\":\"object\",\"properties\":{\"url\":{\"type\":\"string\",\"format\":\"uri\"}," +
+                        "\"ip\":{\"type\":\"string\",\"format\":\"ipv4\"}}}"
+        );
+        assertTrue(ok.issues().isEmpty());
+    }
+
+    @Test
+    @DisplayName("正常：oneOf 恰好匹配一个")
+    void validatesOneOf() {
+        final ValidationOutcome ok = JsonSchemaValidator.validate(
+                "{\"v\":\"x\"}",
+                "{\"type\":\"object\",\"properties\":{\"v\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"number\"}]}}}"
+        );
+        assertTrue(ok.issues().isEmpty(), "恰好匹配一个子约束应通过");
+
+        final ValidationOutcome bad = JsonSchemaValidator.validate(
+                "{\"v\":true}",
+                "{\"type\":\"object\",\"properties\":{\"v\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"number\"}]}}}"
+        );
+        assertTrue(bad.issues().stream().anyMatch(issue -> issue.message().contains("oneOf")),
+                "匹配 0 个应报 oneOf 失败");
+    }
+
+    @Test
+    @DisplayName("正常：anyOf 与 allOf 组合约束")
+    void validatesAnyOfAndAllOf() {
+        final ValidationOutcome anyOk = JsonSchemaValidator.validate(
+                "{\"v\":\"x\"}",
+                "{\"type\":\"object\",\"properties\":{\"v\":{\"anyOf\":[{\"type\":\"number\"},{\"type\":\"string\"}]}}}"
+        );
+        assertTrue(anyOk.issues().isEmpty(), "anyOf 至少一个匹配应通过");
+
+        final ValidationOutcome allBad = JsonSchemaValidator.validate(
+                "{\"v\":5}",
+                "{\"type\":\"object\",\"properties\":{\"v\":{\"allOf\":[{\"type\":\"number\",\"minimum\":10},{\"maximum\":1}]}}}"
+        );
+        assertTrue(allBad.issues().stream().anyMatch(issue -> issue.message().contains("allOf")),
+                "allOf 部分不满足应报失败");
+    }
+
+    @Test
+    @DisplayName("正常：数组长度与元素唯一约束")
+    void validatesArrayConstraints() {
+        final ValidationOutcome ok = JsonSchemaValidator.validate(
+                "{\"list\":[1,2,3]}",
+                "{\"type\":\"object\",\"properties\":{\"list\":{\"type\":\"array\",\"minItems\":2,\"maxItems\":5,\"uniqueItems\":true}}}"
+        );
+        assertTrue(ok.issues().isEmpty());
+
+        final ValidationOutcome bad = JsonSchemaValidator.validate(
+                "{\"list\":[1,1]}",
+                "{\"type\":\"object\",\"properties\":{\"list\":{\"type\":\"array\",\"minItems\":3,\"uniqueItems\":true}}}"
+        );
+        assertTrue(bad.issues().stream().anyMatch(issue -> issue.message().contains("重复")),
+                "重复元素应报 uniqueItems 失败");
+        assertTrue(bad.issues().stream().anyMatch(issue -> issue.message().contains("过少")),
+                "元素过少应报 minItems 失败");
+    }
+
+    @Test
+    @DisplayName("正常：对象属性数量约束")
+    void validatesObjectProperties() {
+        final ValidationOutcome bad = JsonSchemaValidator.validate(
+                "{\"a\":1,\"b\":2,\"c\":3}",
+                "{\"type\":\"object\",\"maxProperties\":2}"
+        );
+        assertTrue(bad.issues().stream().anyMatch(issue -> issue.message().contains("属性过多")));
+    }
+
+    @Test
+    @DisplayName("正常：排他边界与倍数约束")
+    void validatesExclusiveAndMultipleOf() {
+        final ValidationOutcome bad = JsonSchemaValidator.validate(
+                "{\"n\":5}",
+                "{\"type\":\"object\",\"properties\":{\"n\":{\"type\":\"number\",\"exclusiveMinimum\":5,\"multipleOf\":3}}}"
+        );
+        assertTrue(bad.issues().stream().anyMatch(issue -> issue.message().contains("排他最小值")));
+        assertTrue(bad.issues().stream().anyMatch(issue -> issue.message().contains("倍数")));
+    }
 }


### PR DESCRIPTION
- JsonSchemaValidator 新增 format 校验：email/date-time/date/time/uri/uuid/ipv4/ipv6（未知 format 不拦截，符合 Draft 7 语义）
- 新增 oneOf/anyOf/allOf 组合约束（独立 countMatches 校验，不污染主失败项与计数）
- 新增 minItems/maxItems/uniqueItems、minProperties/maxProperties、exclusiveMinimum/exclusiveMaximum、multipleOf
- 实现要点：正则预编译、时间格式 java.time 解析（无 SimpleDateFormat）、数值比较 BigDecimal
- 新增 8 个单元测试（总 481 全绿），i18n 161 键双文件一致