### PR TITLE
feat: 新增键名风格转换、NDJSON 修复与 if/then/else 校验，发布 0.21.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,13 @@ intellijPlatform {
         version = project.version.toString()
         // sinceBuild 自 IGP 2.14 起默认取目标平台 major build（2026.2 → 262），无需显式声明
         changeNotes = """
+            <b>0.21.0</b>
+            <ul>
+                <li>新增键名风格转换：JsonKeyConverter 递归转换对象键（camelCase/snake_case/PascalCase/kebab-case 两两互转），分词处理大小写边界、连续大写缩略词（HTTPServer→http_server）、字母数字边界（user2name→user_2_name）；null 值字段保留（与排序器惯例一致）；转换后键名冲突后者覆盖（JSON 重复键固有限制，类 Javadoc 明示）；工具条新增转换按钮（四种风格弹出菜单）。</li>
+                <li>JSON 修复扩展：NDJSON 流检测组装（整体非法但每行均为合法 JSON 且 ≥2 行时组装为数组，任一行非法即放弃走常规管道），新增 FixType.NDJSON 与修复日志。</li>
+                <li>Schema 校验器补全 if/then/else 条件关键字（2020-12 语义：if 匹配应用 then 否则 else，无 if 时忽略，分支独立校验不污染主失败项与计数）。</li>
+                <li>新增 24 个单元测试（总 525 全绿），i18n 173 键双文件一致。</li>
+            </ul>
             <b>0.20.9</b>
             <ul>
                 <li>JSON Schema 升级最新标准 2020-12：生成器 \$schema 标识更新，Draft 7 文案残留清零（文档/i18n/注释）。</li>

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 // 统一版本表：插件版本、目标平台、Java 基线与第三方依赖版本在此集中维护
 gradle.ext.versions = [
         // 插件版本：发布新版本时递增，并同步更新 build.gradle 中的 changeNotes
-        ver         : "0.20.9",
+        ver         : "0.21.0",
         // 目标 IntelliJ 平台版本：sinceBuild 自 IGP 2.14 起默认取平台 major build（2026.2 → 262），无需显式声明
         idea        : "2026.2",
         // Java 语言基线：toolchain 与 options.release 共用

--- a/src/main/java/com/acme/prism/core/json/JsonKeyConverter.java
+++ b/src/main/java/com/acme/prism/core/json/JsonKeyConverter.java
@@ -1,0 +1,228 @@
+package com.acme.prism.core.json;
+
+import cn.hutool.core.util.StrUtil;
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONArray;
+import com.alibaba.fastjson2.JSONObject;
+import com.alibaba.fastjson2.JSONWriter;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * JSON 键名风格转换器：递归将对象键转换为目标命名风格（camelCase / snake_case /
+ * PascalCase / kebab-case），数组元素与值内容保持不变（null 值字段保留）。
+ *
+ * <p>键分词规则：分隔符（下划线/连字符等非字母数字字符）、大小写边界
+ * （{@code userID → user | ID}）、字母数字边界（{@code user2name → user | 2 | name}）
+ * 均作为分词点；连续大写缩略词按尾字母回退处理（{@code HTTPServer → HTTP | Server}）。
+ * 转换后键名冲突（如 {@code user_id} 与 {@code userId} 同转 {@code userId}）时，
+ * 后者覆盖前者——JSON 对象无法承载重复键，属转换语义固有限制。</p>
+ *
+ * @author 拒绝者
+ * @date 2026-08-13
+ */
+public final class JsonKeyConverter implements JsonOperation {
+
+    /**
+     * 键名命名风格。
+     */
+    public enum KeyCase {
+        /**
+         * 小驼峰：userName
+         */
+        CAMEL("json.key.case.camel"),
+        /**
+         * 下划线：user_name
+         */
+        SNAKE("json.key.case.snake"),
+        /**
+         * 大驼峰：UserName
+         */
+        PASCAL("json.key.case.pascal"),
+        /**
+         * 连字符：user-name
+         */
+        KEBAB("json.key.case.kebab");
+
+        /**
+         * 下划线分隔符
+         */
+        private static final String SEPARATOR_UNDERSCORE = "_";
+        /**
+         * 连字符分隔符
+         */
+        private static final String SEPARATOR_HYPHEN = "-";
+        /**
+         * 风格 i18n 键
+         */
+        private final String i18nKey;
+
+        /**
+         * 构造命名风格。
+         *
+         * @param i18nKey i18n 键
+         */
+        KeyCase(final String i18nKey) {
+            this.i18nKey = i18nKey;
+        }
+
+        /**
+         * 获取 i18n 键。
+         *
+         * @return {@link String }
+         */
+        public String i18nKey() {
+            return this.i18nKey;
+        }
+
+        /**
+         * 按目标风格拼接分词。
+         *
+         * @param tokens 分词（保留原大小写）
+         * @return 拼接后的键名
+         */
+        String join(final List<String> tokens) {
+            if (tokens.isEmpty()) {
+                return "";
+            }
+            return switch (this) {
+                case CAMEL -> joinCamel(tokens, Boolean.FALSE);
+                case PASCAL -> joinCamel(tokens, Boolean.TRUE);
+                case SNAKE -> joinSeparated(tokens, SEPARATOR_UNDERSCORE);
+                case KEBAB -> joinSeparated(tokens, SEPARATOR_HYPHEN);
+            };
+        }
+
+        /**
+         * 驼峰系拼接（camel 首词小写，Pascal 全部首字母大写）。
+         *
+         * @param tokens    分词
+         * @param capitalizeFirst 首个分词是否首字母大写
+         * @return 拼接结果
+         */
+        private static String joinCamel(final List<String> tokens, final boolean capitalizeFirst) {
+            final StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < tokens.size(); i++) {
+                final String token = tokens.get(i).toLowerCase(Locale.ROOT);
+                if (i == 0 && !capitalizeFirst) {
+                    sb.append(token);
+                } else {
+                    sb.append(Character.toUpperCase(token.charAt(0))).append(token.substring(1));
+                }
+            }
+            return sb.toString();
+        }
+
+        /**
+         * 分隔符系拼接（全小写 + 统一分隔符）。
+         *
+         * @param tokens    分词
+         * @param separator 分隔符
+         * @return 拼接结果
+         */
+        private static String joinSeparated(final List<String> tokens, final String separator) {
+            return String.join(separator, tokens.stream().map(t -> t.toLowerCase(Locale.ROOT)).toList());
+        }
+    }
+
+    /**
+     * 目标命名风格
+     */
+    private final KeyCase targetCase;
+
+    /**
+     * 构造键名转换器。
+     *
+     * @param targetCase 目标命名风格
+     */
+    public JsonKeyConverter(final KeyCase targetCase) {
+        this.targetCase = targetCase;
+    }
+
+    /**
+     * JSON 操作契约：递归转换对象键为目标风格。
+     *
+     * @param json 输入 JSON
+     * @return 转换后的 JSON；输入为空或非法时原样返回
+     */
+    @Override
+    public String process(final String json) {
+        if (StrUtil.isBlank(json)) {
+            return json;
+        }
+        try {
+            final Object converted = convertKeys(JSON.parse(json));
+            return JSON.toJSONString(converted, JSONWriter.Feature.PrettyFormat, JSONWriter.Feature.WriteMapNullValue).trim();
+        } catch (final Exception ignored) {
+            return json;
+        }
+    }
+
+    /**
+     * 递归转换值中的对象键。
+     *
+     * @param value 值
+     * @return 转换后的值
+     */
+    private Object convertKeys(final Object value) {
+        if (value instanceof JSONObject obj) {
+            // 重建对象保持插入序，键名转换后放回原位置
+            final JSONObject converted = new JSONObject(obj.size());
+            for (final String key : obj.keySet()) {
+                converted.put(this.targetCase.join(tokenize(key)), this.convertKeys(obj.get(key)));
+            }
+            return converted;
+        }
+        if (value instanceof JSONArray arr) {
+            final JSONArray converted = new JSONArray(arr.size());
+            for (final Object item : arr) {
+                converted.add(this.convertKeys(item));
+            }
+            return converted;
+        }
+        return value;
+    }
+
+    /**
+     * 将键名切分为分词：分隔符、大小写边界、字母数字边界均为分词点。
+     *
+     * @param key 键名
+     * @return 分词列表（保留原大小写）
+     */
+    private static List<String> tokenize(final String key) {
+        final List<String> tokens = new ArrayList<>(4);
+        final StringBuilder current = new StringBuilder();
+        for (int i = 0; i < key.length(); i++) {
+            final char c = key.charAt(i);
+            if (!Character.isLetterOrDigit(c)) {
+                // 分隔符：结束当前分词
+                if (!current.isEmpty()) {
+                    tokens.add(current.toString());
+                    current.setLength(0);
+                }
+                continue;
+            }
+            if (!current.isEmpty()) {
+                final char prev = current.charAt(current.length() - 1);
+                // 小写/数字 → 大写：userID → user | ID
+                final boolean camelBoundary = Character.isUpperCase(c) && !Character.isUpperCase(prev);
+                // 字母 ↔ 数字：user2name → user | 2 | name
+                final boolean digitBoundary = Character.isDigit(c) != Character.isDigit(prev);
+                // 连续大写缩略词结尾：HTTPServer → HTTP | Server（大写后跟小写时，缩略词整体弹出）
+                final boolean acronymBoundary = Character.isUpperCase(prev) && Character.isUpperCase(c)
+                        && i + 1 < key.length() && Character.isLowerCase(key.charAt(i + 1));
+                if (camelBoundary || digitBoundary || acronymBoundary) {
+                    tokens.add(current.toString());
+                    current.setLength(0);
+                }
+            }
+            current.append(c);
+        }
+        if (!current.isEmpty()) {
+            tokens.add(current.toString());
+        }
+        return tokens;
+    }
+}

--- a/src/main/java/com/acme/prism/core/json/JsonOperation.java
+++ b/src/main/java/com/acme/prism/core/json/JsonOperation.java
@@ -9,7 +9,7 @@ import com.alibaba.fastjson2.JSON;
  * @date 2025-01-18
  */
 public sealed interface JsonOperation permits
-        JsonCompressor, JsonEscaper, JsonFlattener, JsonFormatter, JsonMockGenerator,
+        JsonCompressor, JsonEscaper, JsonFlattener, JsonFormatter, JsonKeyConverter, JsonMockGenerator,
         JsonRepairer, JsonSchemaGenerator, JsonSearchEngine, JsonSorter, JsonUnEscaper, JsonUnflattener {
     /**
      * JSON操作

--- a/src/main/java/com/acme/prism/core/json/JsonRepairer.java
+++ b/src/main/java/com/acme/prism/core/json/JsonRepairer.java
@@ -16,8 +16,9 @@ import java.util.regex.Pattern;
  * JSON 修复器：自动修复损坏的 JSON（单引号、缺逗号、尾逗号、注释、JSONP 包装、
  * 未加引号的键、非标准字面量等），输出修复后的 JSON、修复点日志与置信度。
  *
- * <p>修复采用分层管道：BOM 剥离 → JSONP 剥离 → 单引号规范化 → 裸键补引号 →
- * 注释剥离 → 字符串提取保护 → 骨架修复（逗号/字面量）→ 字符串还原 → 合法性验证。
+ * <p>修复采用分层管道：BOM 剥离 → NDJSON 检测组装 → Markdown 代码块剥离 → JSONP 剥离 →
+ * 日志前缀剥离 → 特殊引号规范化 → 单引号转双引号 → 裸键补引号 → 注释剥离 →
+ * 字符串提取保护 → 骨架修复（逗号/字面量/闭合括号）→ 字符串还原 → 合法性验证。
  * 字符串内容在修复期间被占位符保护，避免正则误伤值内容。</p>
  *
  * @author 拒绝者
@@ -68,6 +69,22 @@ public final class JsonRepairer implements JsonOperation {
      * 非标准字面量模式
      */
     private static final Pattern LITERAL = Pattern.compile("\\b(undefined|None|True|False|NaN|Infinity)\\b");
+    /**
+     * NDJSON 组装缩进前缀
+     */
+    private static final String NDJSON_INDENT = "\n  ";
+    /**
+     * NDJSON 数组闭合行
+     */
+    private static final String NDJSON_CLOSE = "\n]";
+    /**
+     * NDJSON 数组元素分隔（逗号 + 缩进）
+     */
+    private static final String NDJSON_SEPARATOR = ",\n  ";
+    /**
+     * NDJSON 数组开括号
+     */
+    private static final String NDJSON_OPEN = "[";
 
     /**
      * 修复类型与对应置信度扣减值、i18n 键。
@@ -120,7 +137,11 @@ public final class JsonRepairer implements JsonOperation {
         /**
          * 非标准字面量规范化
          */
-        LITERAL("json.repair.fix.literal", 0.05);
+        LITERAL("json.repair.fix.literal", 0.05),
+        /**
+         * NDJSON 流组装为 JSON 数组
+         */
+        NDJSON("json.repair.fix.ndjson", 0.10);
 
         /**
          * 修复类型 i18n 键
@@ -188,36 +209,44 @@ public final class JsonRepairer implements JsonOperation {
             text = text.substring(1);
             fixes.add(FixType.BOM);
         }
-        // 2. 剥离 Markdown 代码块（```json ... ```）
+        // 2. NDJSON 检测：整体非法但每行均为合法 JSON 时，组装为数组（短路返回）
+        if (!JSON.isValid(text)) {
+            final String ndjson = toNdjsonArray(text);
+            if (Objects.nonNull(ndjson)) {
+                fixes.add(FixType.NDJSON);
+                return new RepairResult(ndjson, fixes.stream().distinct().toList(), confidence(fixes));
+            }
+        }
+        // 3. 剥离 Markdown 代码块（```json ... ```）
         final String fenced = stripFencedCodeBlock(text);
         if (Objects.nonNull(fenced)) {
             text = fenced;
             fixes.add(FixType.FENCE);
         }
-        // 3. 剥离 JSONP 包装
+        // 4. 剥离 JSONP 包装
         final String stripped = stripJsonp(text);
         if (Objects.nonNull(stripped)) {
             text = stripped;
             fixes.add(FixType.JSONP);
         }
-        // 4. 剥离日志前缀（INFO: {...} / 时间戳前缀）
+        // 5. 剥离日志前缀（INFO: {...} / 时间戳前缀）
         final String logStripped = stripLogPrefix(text);
         if (Objects.nonNull(logStripped)) {
             text = logStripped;
             fixes.add(FixType.LOG_PREFIX);
         }
-        // 5. 特殊引号转标准引号（“ ” ‘ ’ → " '）
+        // 6. 特殊引号转标准引号（“ ” ‘ ’ → " '）
         text = normalizeSpecialQuotes(text, fixes);
-        // 6. 单引号转双引号（规范化后字符串统一为双引号）
+        // 7. 单引号转双引号（规范化后字符串统一为双引号）
         text = normalizeSingleQuotes(text, fixes);
-        // 7. 未加引号的键补引号
+        // 8. 未加引号的键补引号
         text = fixUnquotedKeys(text, fixes);
-        // 8. 剥离注释
+        // 9. 剥离注释
         text = stripComments(text, fixes);
-        // 9. 提取字符串为占位符，保护值内容
+        // 10. 提取字符串为占位符，保护值内容
         final StringExtraction extraction = extractStrings(text);
         String skeleton = extraction.skeleton();
-        // 10. 骨架修复（骨架无字符串内容，正则安全）
+        // 11. 骨架修复（骨架无字符串内容，正则安全）
         final String beforeTrailing = skeleton;
         skeleton = TRAILING_COMMA.matcher(skeleton).replaceAll("$1");
         if (!skeleton.equals(beforeTrailing)) {
@@ -245,15 +274,15 @@ public final class JsonRepairer implements JsonOperation {
         if (!skeleton.equals(beforeLiteral)) {
             fixes.add(FixType.LITERAL);
         }
-        // 11. 补齐缺失闭合括号（截断 JSON 场景）
+        // 12. 补齐缺失闭合括号（截断 JSON 场景）
         final String beforeBracket = skeleton;
         skeleton = closeBrackets(skeleton);
         if (!skeleton.equals(beforeBracket)) {
             fixes.add(FixType.MISSING_BRACKET);
         }
-        // 12. 还原字符串
+        // 13. 还原字符串
         final String restored = restoreStrings(skeleton, extraction.strings());
-        // 13. 合法性验证，失败不返回修复结果（绝不写回非法内容）
+        // 14. 合法性验证，失败不返回修复结果（绝不写回非法内容）
         if (!JSON.isValid(restored)) {
             return null;
         }
@@ -287,6 +316,38 @@ public final class JsonRepairer implements JsonOperation {
             value -= fix.penalty();
         }
         return Math.max(value, 0.1d);
+    }
+
+    /**
+     * NDJSON 流组装为 JSON 数组：整体非法但每行（非空白）均为合法 JSON 时生效。
+     * <p>至少两行合法 JSON 才算 NDJSON 流（单行合法 JSON 直接走 {@link JSON#isValid(String)} 短路，
+     * 不会进入本方法）；任一行非法即放弃，返回 {@code null} 走常规修复管道。</p>
+     *
+     * @param text 输入文本
+     * @return 组装后的 JSON 数组；非 NDJSON 流返回 {@code null}
+     */
+    private static String toNdjsonArray(final String text) {
+        final List<String> jsonLines = new ArrayList<>();
+        for (final String line : text.split("\\R")) {
+            if (StrUtil.isBlank(line)) {
+                continue;
+            }
+            final String stripped = line.strip();
+            if (!JSON.isValid(stripped)) {
+                return null;
+            }
+            jsonLines.add(stripped);
+        }
+        if (jsonLines.size() < 2) {
+            return null;
+        }
+        final StringBuilder sb = new StringBuilder(text.length() + 16);
+        sb.append(NDJSON_OPEN);
+        for (int i = 0; i < jsonLines.size(); i++) {
+            sb.append(i > 0 ? NDJSON_SEPARATOR : NDJSON_INDENT).append(jsonLines.get(i));
+        }
+        sb.append(NDJSON_CLOSE);
+        return sb.toString();
     }
 
     /**

--- a/src/main/java/com/acme/prism/core/json/JsonSchemaValidator.java
+++ b/src/main/java/com/acme/prism/core/json/JsonSchemaValidator.java
@@ -27,7 +27,7 @@ import java.util.regex.PatternSyntaxException;
  *
  * <p>支持关键字：type（含多类型数组）、required、properties、items、enum、minLength/maxLength、
  * minimum/maximum、pattern、format（email/date-time/date/time/uri/uuid/ipv4/ipv6）、
- * oneOf/anyOf/allOf、minItems/maxItems/uniqueItems、minProperties/maxProperties、
+ * oneOf/anyOf/allOf/not、if/then/else、minItems/maxItems/uniqueItems、minProperties/maxProperties、
  * exclusiveMinimum/exclusiveMaximum、multipleOf。输出每个失败项（路径/期望/实际/说明）
  * 与已校验字段总数。</p>
  *
@@ -146,6 +146,8 @@ public final class JsonSchemaValidator {
         if (notSchema instanceof final JSONObject notObj && checkMatches(value, notObj, path)) {
             issues.add(new ValidationIssue(path, "不匹配否定约束", String.valueOf(value), "not 约束不满足"));
         }
+        // 3.5 条件约束校验（if/then/else，2020-12 语义）
+        validateConditionals(value, schemaNode, path, issues);
         // 4. 字符串约束
         if (value instanceof final String text) {
             validateString(text, schemaNode, path, issues);
@@ -161,6 +163,31 @@ public final class JsonSchemaValidator {
         // 7. 数组：长度约束 + 元素唯一 + 元组校验 + 元素递归
         if (value instanceof final JSONArray arr) {
             validateArray(arr, schemaNode, path, issues, checked);
+        }
+    }
+
+    /**
+     * 校验条件约束（if/then/else，2020-12 语义）。
+     * <p>{@code if} 子 schema 匹配时应用 {@code then}，否则应用 {@code else}；
+     * 无 {@code if} 时 {@code then}/{@code else} 被忽略（标准语义）。
+     * 分支校验独立计数（不污染主计数），失败项并入主列表。</p>
+     *
+     * @param value      实际值
+     * @param schemaNode Schema 节点
+     * @param path       路径
+     * @param issues     失败项收集器
+     */
+    private static void validateConditionals(final Object value, final JSONObject schemaNode, final String path,
+                                             final List<ValidationIssue> issues) {
+        final Object ifSchema = schemaNode.get("if");
+        if (ifSchema instanceof final JSONObject ifObj) {
+            if (checkMatches(value, ifObj, path)) {
+                if (schemaNode.get("then") instanceof final JSONObject thenObj) {
+                    validateValue(value, thenObj, path, issues, new AtomicInteger());
+                }
+            } else if (schemaNode.get("else") instanceof final JSONObject elseObj) {
+                validateValue(value, elseObj, path, issues, new AtomicInteger());
+            }
         }
     }
 

--- a/src/main/java/com/acme/prism/ui/panel/MainPanel.java
+++ b/src/main/java/com/acme/prism/ui/panel/MainPanel.java
@@ -203,6 +203,7 @@ public class MainPanel {
                 _ -> this.optJson(redoButton, undoButton, editor.getEditor(), new JsonSchemaGenerator())));
         panel.add(this.createToolButton(BUNDLE.getString("json.mock.generate"), AllIcons.Actions.Rerun,
                 _ -> this.optJson(redoButton, undoButton, editor.getEditor(), new JsonMockGenerator())));
+        panel.add(this.createKeyCaseButton(redoButton, undoButton, editor));
         panel.add(this.createToolButton(BUNDLE.getString("json.validate"), AllIcons.General.GreenCheckmark,
                 _ -> this.showValidateDialog(editor)));
         panel.add(this.createToolButton(BUNDLE.getString("json.analyze"), AllIcons.Actions.Find,
@@ -211,11 +212,45 @@ public class MainPanel {
     }
 
     /**
+     * 创建键名风格转换按钮：点击弹出四种命名风格菜单，选择后即时转换并写回编辑器。
+     *
+     * @param redoButton 重做按钮
+     * @param undoButton 撤消按钮
+     * @param editor     当前编辑
+     * @return 按钮
+     */
+    private JButton createKeyCaseButton(final JButton redoButton, final JButton undoButton, final EditorTextField editor) {
+        final JButton button = this.createToolButton(BUNDLE.getString("json.key.case.convert"), AllIcons.Json.Object, null);
+        button.addActionListener(_ -> this.showKeyCaseMenu(button, redoButton, undoButton, editor));
+        return button;
+    }
+
+    /**
+     * 弹出键名风格选择菜单（四种命名风格）。
+     *
+     * @param invoker    触发按钮
+     * @param redoButton 重做按钮
+     * @param undoButton 撤消按钮
+     * @param editor     当前编辑
+     */
+    private void showKeyCaseMenu(final JButton invoker, final JButton redoButton, final JButton undoButton,
+                                 final EditorTextField editor) {
+        if (Objects.isNull(editor) || Objects.isNull(editor.getProject())) return;
+        final JPopupMenu menu = new JPopupMenu();
+        for (final JsonKeyConverter.KeyCase keyCase : JsonKeyConverter.KeyCase.values()) {
+            final JMenuItem item = new JMenuItem(BUNDLE.getString(keyCase.i18nKey()));
+            item.addActionListener(_ -> this.optJson(redoButton, undoButton, editor.getEditor(), new JsonKeyConverter(keyCase)));
+            menu.add(item);
+        }
+        menu.show(invoker, 0, invoker.getHeight());
+    }
+
+    /**
      * 创建工具条按钮（图标 + 提示文本）。
      *
      * @param tooltip 提示文本
      * @param icon    图标
-     * @param action  点击动作
+     * @param action  点击动作；为 {@code null} 时不绑定动作（由调用方另行绑定）
      * @return 按钮
      */
     private JButton createToolButton(final String tooltip, final Icon icon, final ActionListener action) {
@@ -224,7 +259,9 @@ public class MainPanel {
         button.setToolTipText(tooltip);
         button.setMargin(JBUI.emptyInsets());
         button.setPreferredSize(new Dimension(BUTTON_SIZE, BUTTON_SIZE));
-        button.addActionListener(action);
+        if (Objects.nonNull(action)) {
+            button.addActionListener(action);
+        }
         return button;
     }
 

--- a/src/main/resources/messages/PrismBundle.properties
+++ b/src/main/resources/messages/PrismBundle.properties
@@ -169,5 +169,13 @@ json.repair.fix.fence=Removed Markdown code block
 json.repair.fix.log.prefix=Removed log prefix
 json.repair.fix.special.quote=Converted special quotes
 json.repair.fix.missing.bracket=Added missing closing brackets
+json.repair.fix.ndjson=Assembled NDJSON stream into array
+
+json.key.case.convert=Convert Key Case
+json.key.case.convert.desc=Convert JSON object keys to naming style
+json.key.case.camel=camelCase
+json.key.case.snake=snake_case
+json.key.case.pascal=PascalCase
+json.key.case.kebab=kebab-case
 
 json.tool.empty.editor=Please enter JSON content in the editor first

--- a/src/main/resources/messages/PrismBundle_zh_CN.properties
+++ b/src/main/resources/messages/PrismBundle_zh_CN.properties
@@ -169,5 +169,13 @@ json.repair.fix.fence=剥离 Markdown 代码块
 json.repair.fix.log.prefix=剥离日志前缀
 json.repair.fix.special.quote=转换特殊引号
 json.repair.fix.missing.bracket=补齐缺失闭合括号
+json.repair.fix.ndjson=将 NDJSON 流组装为数组
+
+json.key.case.convert=键名风格转换
+json.key.case.convert.desc=将 JSON 对象键转换为目标命名风格
+json.key.case.camel=小驼峰（camelCase）
+json.key.case.snake=下划线（snake_case）
+json.key.case.pascal=大驼峰（PascalCase）
+json.key.case.kebab=连字符（kebab-case）
 
 json.tool.empty.editor=请先在编辑器中输入 JSON 内容

--- a/src/test/java/com/acme/prism/core/json/JsonKeyConverterTest.java
+++ b/src/test/java/com/acme/prism/core/json/JsonKeyConverterTest.java
@@ -1,0 +1,146 @@
+package com.acme.prism.core.json;
+
+import com.acme.prism.core.json.JsonKeyConverter.KeyCase;
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONArray;
+import com.alibaba.fastjson2.JSONObject;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * JSON 键名风格转换器单元测试
+ *
+ * @author 拒绝者
+ * @date 2026-08-13
+ */
+class JsonKeyConverterTest {
+
+    @Test
+    @DisplayName("正常：snake_case 转 camelCase")
+    void convertsSnakeToCamel() {
+        final String result = new JsonKeyConverter(KeyCase.CAMEL).process("{\"user_name\": 1, \"first_name\": \"a\"}");
+        assertNotNull(result);
+        final JSONObject obj = JSON.parseObject(result);
+        assertTrue(obj.containsKey("userName"));
+        assertTrue(obj.containsKey("firstName"));
+        assertEquals(1, obj.getIntValue("userName"));
+    }
+
+    @Test
+    @DisplayName("正常：camelCase 转 snake_case（含缩写 userID）")
+    void convertsCamelToSnake() {
+        final String result = new JsonKeyConverter(KeyCase.SNAKE).process("{\"userID\": 1, \"phoneNumber\": \"x\"}");
+        final JSONObject obj = JSON.parseObject(result);
+        assertTrue(obj.containsKey("user_id"));
+        assertTrue(obj.containsKey("phone_number"));
+    }
+
+    @Test
+    @DisplayName("正常：连续大写缩略词 HTTPServer 转 http_server")
+    void handlesAcronymBoundary() {
+        final String result = new JsonKeyConverter(KeyCase.SNAKE).process("{\"HTTPServer\": 1}");
+        final JSONObject obj = JSON.parseObject(result);
+        assertTrue(obj.containsKey("http_server"), result);
+    }
+
+    @Test
+    @DisplayName("正常：字母数字边界 user2name 转 user_2_name")
+    void handlesDigitBoundary() {
+        final String result = new JsonKeyConverter(KeyCase.SNAKE).process("{\"user2name\": 1}");
+        final JSONObject obj = JSON.parseObject(result);
+        assertTrue(obj.containsKey("user_2_name"), result);
+    }
+
+    @Test
+    @DisplayName("正常：kebab-case 转 camelCase")
+    void convertsKebabToCamel() {
+        final String result = new JsonKeyConverter(KeyCase.CAMEL).process("{\"user-name\": 1}");
+        final JSONObject obj = JSON.parseObject(result);
+        assertTrue(obj.containsKey("userName"), result);
+    }
+
+    @Test
+    @DisplayName("正常：snake_case 转 PascalCase")
+    void convertsSnakeToPascal() {
+        final String result = new JsonKeyConverter(KeyCase.PASCAL).process("{\"user_name\": 1}");
+        final JSONObject obj = JSON.parseObject(result);
+        assertTrue(obj.containsKey("UserName"), result);
+    }
+
+    @Test
+    @DisplayName("正常：snake_case 转 kebab-case")
+    void convertsSnakeToKebab() {
+        final String result = new JsonKeyConverter(KeyCase.KEBAB).process("{\"user_name\": 1}");
+        final JSONObject obj = JSON.parseObject(result);
+        assertTrue(obj.containsKey("user-name"), result);
+    }
+
+    @Test
+    @DisplayName("正常：数组内嵌套对象键递归转换")
+    void convertsNestedArrayKeys() {
+        final String result = new JsonKeyConverter(KeyCase.CAMEL)
+                .process("{\"items\": [{\"item_id\": 1}, {\"item_id\": 2}]}");
+        final JSONArray items = JSON.parseObject(result).getJSONArray("items");
+        assertNotNull(items);
+        assertEquals(2, items.size());
+        assertTrue(items.getJSONObject(0).containsKey("itemId"));
+        assertTrue(items.getJSONObject(1).containsKey("itemId"));
+    }
+
+    @Test
+    @DisplayName("正常：值内容不参与转换")
+    void keepsValuesUntouched() {
+        final String result = new JsonKeyConverter(KeyCase.CAMEL).process("{\"user_name\": \"hello_world\"}");
+        final JSONObject obj = JSON.parseObject(result);
+        assertEquals("hello_world", obj.getString("userName"));
+    }
+
+    @Test
+    @DisplayName("正常：null 值字段保留（与排序器惯例一致）")
+    void keepsNullValues() {
+        final String result = new JsonKeyConverter(KeyCase.CAMEL).process("{\"user_name\": null, \"age\": 1}");
+        final JSONObject obj = JSON.parseObject(result);
+        assertTrue(obj.containsKey("userName"), result);
+        assertNull(obj.get("userName"));
+        assertEquals(1, obj.getIntValue("age"));
+    }
+
+    @Test
+    @DisplayName("边界：转换后键名冲突时后者覆盖前者（JSON 无法承载重复键）")
+    void laterKeyWinsOnCollision() {
+        final String result = new JsonKeyConverter(KeyCase.CAMEL).process("{\"user_id\": 1, \"userId\": 2}");
+        final JSONObject obj = JSON.parseObject(result);
+        assertFalse(obj.containsKey("user_id"), result);
+        assertTrue(obj.containsKey("userId"), result);
+        assertEquals(2, obj.getIntValue("userId"), "后者覆盖前者，属 JSON 重复键固有限制");
+    }
+
+    @Test
+    @DisplayName("正常：连续分隔符键名归一化")
+    void normalizesMixedSeparators() {
+        final String result = new JsonKeyConverter(KeyCase.SNAKE).process("{\"user--name\": 1, \"other__key\": 2}");
+        final JSONObject obj = JSON.parseObject(result);
+        assertTrue(obj.containsKey("user_name"), result);
+        assertTrue(obj.containsKey("other_key"), result);
+        assertEquals(1, obj.getIntValue("user_name"));
+        assertEquals(2, obj.getIntValue("other_key"));
+    }
+
+    @Test
+    @DisplayName("异常：空输入与非法 JSON 原样返回")
+    void returnsInputForBlankOrInvalid() {
+        final JsonKeyConverter converter = new JsonKeyConverter(KeyCase.CAMEL);
+        assertEquals("", converter.process(""));
+        assertEquals("{bad", converter.process("{bad"));
+    }
+
+    @Test
+    @DisplayName("边界：空键名保持为空键")
+    void keepsEmptyKey() {
+        final String result = new JsonKeyConverter(KeyCase.SNAKE).process("{\"\": 1}");
+        final JSONObject obj = JSON.parseObject(result);
+        assertTrue(obj.containsKey(""), result);
+    }
+}

--- a/src/test/java/com/acme/prism/core/json/JsonRepairerTest.java
+++ b/src/test/java/com/acme/prism/core/json/JsonRepairerTest.java
@@ -3,11 +3,13 @@ package com.acme.prism.core.json;
 import com.acme.prism.core.json.JsonRepairer.FixType;
 import com.acme.prism.core.json.JsonRepairer.RepairResult;
 import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONArray;
 import com.alibaba.fastjson2.JSONObject;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -248,5 +250,55 @@ class JsonRepairerTest {
         assertNotNull(result);
         final List<FixType> fixes = result.fixes();
         assertEquals(fixes.stream().distinct().toList(), fixes, "修复类型列表应去重");
+    }
+
+    @Test
+    @DisplayName("正常：NDJSON 两行流组装为数组")
+    void assemblesNdjsonStream() {
+        final RepairResult result = JsonRepairer.repair("{\"a\":1}\n{\"b\":2}");
+        assertNotNull(result);
+        final JSONArray arr = JSON.parseArray(result.json());
+        assertNotNull(arr);
+        assertEquals(2, arr.size());
+        assertTrue(result.fixes().contains(FixType.NDJSON));
+    }
+
+    @Test
+    @DisplayName("正常：NDJSON 空行被忽略，内容行全部保留")
+    void ignoresBlankLinesInNdjson() {
+        final RepairResult result = JsonRepairer.repair("{\"a\":1}\n\n{\"b\":2}\n");
+        assertNotNull(result);
+        final JSONArray arr = JSON.parseArray(result.json());
+        assertNotNull(arr);
+        assertEquals(2, arr.size());
+    }
+
+    @Test
+    @DisplayName("正常：NDJSON 行内嵌套数组与对象完整保留")
+    void keepsNestedContentInNdjson() {
+        final RepairResult result = JsonRepairer.repair("{\"a\":[1,2]}\n{\"b\":{\"c\":3}}");
+        assertNotNull(result);
+        final JSONArray arr = JSON.parseArray(result.json());
+        assertNotNull(arr);
+        assertEquals(2, arr.size());
+        assertEquals(2, arr.getJSONObject(0).getJSONArray("a").size());
+        assertEquals(3, arr.getJSONObject(1).getJSONObject("b").getIntValue("c"));
+    }
+
+    @Test
+    @DisplayName("异常：任一行非法则不走 NDJSON（走常规管道）")
+    void rejectsNdjsonWithInvalidLine() {
+        final RepairResult result = JsonRepairer.repair("{\"a\":1}\n{bad");
+        if (Objects.nonNull(result)) {
+            assertFalse(result.fixes().contains(FixType.NDJSON), "含非法行不应按 NDJSON 组装");
+        }
+    }
+
+    @Test
+    @DisplayName("边界：单行合法 JSON 不触发 NDJSON")
+    void singleLineJsonNotNdjson() {
+        final RepairResult result = JsonRepairer.repair("{\"a\":1}");
+        assertNotNull(result);
+        assertFalse(result.fixes().contains(FixType.NDJSON));
     }
 }

--- a/src/test/java/com/acme/prism/core/json/JsonSchemaValidatorTest.java
+++ b/src/test/java/com/acme/prism/core/json/JsonSchemaValidatorTest.java
@@ -355,4 +355,56 @@ class JsonSchemaValidatorTest {
         );
         assertTrue(bad.issues().stream().anyMatch(issue -> issue.message().contains("not")));
     }
+
+    @Test
+    @DisplayName("正常：if 匹配时应用 then，通过")
+    void appliesThenWhenIfMatches() {
+        final ValidationOutcome ok = JsonSchemaValidator.validate(
+                "{\"country\":\"US\",\"postal\":\"12345\"}",
+                "{\"type\":\"object\",\"if\":{\"properties\":{\"country\":{\"const\":\"US\"}}},\"then\":{\"required\":[\"postal\"]}}"
+        );
+        assertTrue(ok.issues().isEmpty(), "if 匹配且 then 满足应通过");
+    }
+
+    @Test
+    @DisplayName("异常：if 匹配时应用 then，then 失败被检出")
+    void reportsThenFailure() {
+        final ValidationOutcome bad = JsonSchemaValidator.validate(
+                "{\"country\":\"US\"}",
+                "{\"type\":\"object\",\"if\":{\"properties\":{\"country\":{\"const\":\"US\"}}},\"then\":{\"required\":[\"postal\"]}}"
+        );
+        assertTrue(bad.issues().stream().anyMatch(issue -> issue.message().contains("postal")),
+                "if 匹配但 then 不满足应检出 postal 缺失");
+    }
+
+    @Test
+    @DisplayName("异常：if 不匹配时应用 else，else 失败被检出")
+    void reportsElseFailure() {
+        final ValidationOutcome bad = JsonSchemaValidator.validate(
+                "{\"country\":\"CN\"}",
+                "{\"type\":\"object\",\"if\":{\"properties\":{\"country\":{\"const\":\"US\"}}},\"else\":{\"required\":[\"province\"]}}"
+        );
+        assertTrue(bad.issues().stream().anyMatch(issue -> issue.message().contains("province")),
+                "if 不匹配且 else 不满足应检出 province 缺失");
+    }
+
+    @Test
+    @DisplayName("正常：if 不匹配且无 else 时通过")
+    void passesWhenIfMismatchesWithoutElse() {
+        final ValidationOutcome ok = JsonSchemaValidator.validate(
+                "{\"country\":\"CN\"}",
+                "{\"type\":\"object\",\"if\":{\"properties\":{\"country\":{\"const\":\"US\"}}},\"then\":{\"required\":[\"postal\"]}}"
+        );
+        assertTrue(ok.issues().isEmpty(), "if 不匹配且无 else 应通过");
+    }
+
+    @Test
+    @DisplayName("边界：无 if 时 then/else 被忽略")
+    void ignoresThenWithoutIf() {
+        final ValidationOutcome ok = JsonSchemaValidator.validate(
+                "{\"v\":1}",
+                "{\"type\":\"object\",\"then\":{\"required\":[\"postal\"]}}"
+        );
+        assertTrue(ok.issues().isEmpty(), "无 if 时 then 应被忽略（标准语义）");
+    }
 }


### PR DESCRIPTION
- 新增 JsonKeyConverter：camelCase/snake_case/PascalCase/kebab-case 递归转换，分词处理大小写边界、连续大写缩略词（HTTPServer→http_server）、字母数字边界（user2name→user_2_name）；null 值字段保留（对齐排序器惯例）；转换后键名冲突后者覆盖（JSON 重复键固有限制，Javadoc 明示）
- 工具条新增键名风格转换按钮（四种风格弹出菜单）；右键菜单按用户反馈不追加
- JsonRepairer 新增 NDJSON 检测组装：整体非法但每行合法 JSON（≥2 行）时组装为数组，任一行非法即走常规管道；新增 FixType.NDJSON 与 i18n 修复日志
- JsonSchemaValidator 补全 if/then/else（2020-12 语义）：if 匹配应用 then 否则 else，无 if 时忽略，分支独立校验不污染主计数
- 新增 24 个单元测试（总 525 全绿），i18n 173 键双文件一致