### PR TITLE
feat: MongoDB 包装修复、Schema 四关键字与 Markdown 转换，构建升级 Gradle 9.7.0，发布 0.22.0

### DIFF
--- a/.github/workflows/build_jar.yml
+++ b/.github/workflows/build_jar.yml
@@ -19,7 +19,7 @@ jobs:
 
     env:
       JAVA_VERSION: "25"
-      GRADLE_VERSION: "9.6.1"
+      GRADLE_VERSION: "9.7.0"
 
     steps:
       - name: Checkout code

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,14 +21,14 @@
 **核心功能：**
 
 - JSON 编辑、格式化、压缩、转义与反转义
-- 自动修复损坏 JSON（单引号/缺逗号/尾逗号/注释/JSONP 包装/裸键/非标准字面量），带置信度与修复日志
+- 自动修复损坏 JSON（单引号/缺逗号/尾逗号/注释/JSONP 包装/裸键/非标准字面量/NDJSON 流/MongoDB 扩展 JSON 包装），带置信度与修复日志
 - 按键递归排序、扁平化/还原（点号键与嵌套结构互转）、JSON Schema（2020-12）生成
 - 右侧面板深度工具：工具条（修复/排序/展开/还原/Schema/分析）、结构分析（键/对象/数组/深度/大小、重复键检测）、树形面板展开全部/折叠全部与选中节点路径/值详情
 - 从 JSON 生成 Java Class / Record
 - 从 Java 类字段复制 JSON 结构
 - JsonPath / JMESPath 查询与树形浏览
 - URL、JWT、本地文件路径、Web 路径自动解析为 JSON
-- JSON 与 XML / YAML / TOML / Properties / CSV / XLSX / Base64 / URL Params 互转
+- JSON 与 XML / YAML / TOML / Properties / CSV / XLSX / Base64 / URL Params / Markdown 互转
 - Search Everywhere 集成：项目搜索、HTTP 请求文件搜索、端口搜索、压缩包内容搜索
 - 项目树中将压缩包（zip / 7z / jar / war / ear / tar / tar.gz / tgz / tar.bz2 / tbz2 / tar.xz / txz / gz / bz2 /
   xz）作为目录展开浏览
@@ -39,7 +39,7 @@
 ## 技术栈
 
 - **语言**: Java 25（toolchain 与 `options.release` 均取自版本表 `jvm`）
-- **构建工具**: Gradle 9.6.1 + IntelliJ Platform Gradle Plugin 2.18.1
+- **构建工具**: Gradle 9.7.0 + IntelliJ Platform Gradle Plugin 2.18.1
 - **目标平台**: IntelliJ IDEA 2026.2（sinceBuild = 262，由 IGP 2.14+ 按目标平台 major build 默认生成，无需显式声明）
 - **UI 框架**: IntelliJ Platform UI（Swing-based）
 - **字符编码**: 全项目 UTF-8
@@ -136,6 +136,7 @@ src/main/
 │   │   │       ├── XmlConverter.java / YamlConverter.java / TomlConverter.java
 │   │   │       ├── CsvConverter.java / XlsxConverter.java
 │   │   │       ├── PropertiesConverter.java / Base64Converter.java / UrlParamsConverter.java
+│   │   │       ├── SqlConverter.java / MarkdownTableConverter.java
 │   │   │       ├── ClassConverter.java / RecordConverter.java
 │   │   │       └── JavaStructure.java / TableStructure.java  # 结构模型
 │   │   ├── rainbow/               # 彩虹高亮
@@ -192,7 +193,7 @@ src/main/
 
 ## 构建命令
 
-项目已生成 Gradle Wrapper（`gradlew` / `gradlew.bat`，固定 9.6.1），优先使用 `./gradlew`；也可使用系统 `gradle` 命令：
+项目已生成 Gradle Wrapper（`gradlew` / `gradlew.bat`，固定 9.7.0），优先使用 `./gradlew`；也可使用系统 `gradle` 命令：
 
 ```bash
 # 打印版本信息
@@ -344,7 +345,7 @@ Everywhere、项目树节点、代码地图渲染）不做单元测试，验证�
 GitHub Actions 工作流 `.github/workflows/build_jar.yml`：
 
 - **触发方式**: 手动 (`workflow_dispatch`)
-- **运行环境**: `ubuntu-latest`，Java 25，Gradle 9.6.1
+- **运行环境**: `ubuntu-latest`，Java 25，Gradle 9.7.0
 - **流程**: 从 `settings.gradle` 提取版本号 → 缓存 IntelliJ Platform 构件 → `test` + `buildPlugin` +
   `verifyPluginStructure` → 上传 ZIP 工件 → 创建 GitHub Release
 
@@ -382,7 +383,7 @@ GitHub Actions 工作流 `.github/workflows/build_jar.yml`：
 private static Map<AnyFile, DataFormatConverter> createConverters() {
     final EnumMap<AnyFile, DataFormatConverter> converters = new EnumMap<>(AnyFile.class);
     register(converters, AnyFile.XML, new XmlConverter());
-    // ... 共 10 个转换器
+    // ... 共 12 个转换器
     return Map.copyOf(converters);
 }
 ```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![GitHub Repo stars](https://img.shields.io/github/stars/fc6a1b03/prism?style=flat&logo=github)](https://github.com/fc6a1b03/prism/stargazers)
 [![GitHub total commits](https://img.shields.io/github/commit-activity/t/fc6a1b03/prism)](https://github.com/fc6a1b03/prism/commits)
 [![JDK](https://img.shields.io/badge/JDK-25-green.svg)](https://www.oracle.com/java/)
-[![Gradle](https://img.shields.io/badge/Gradle-9.6.1-02303A.svg)](https://gradle.org)
+[![Gradle](https://img.shields.io/badge/Gradle-9.7.0-02303A.svg)](https://gradle.org)
 [![IDEA](https://img.shields.io/badge/IntelliJ_IDEA-2026.2-FF318C.svg)](https://www.jetbrains.com/idea)
 [![GitHub Release](https://img.shields.io/github/v/release/fc6a1b03/prism)](https://github.com/fc6a1b03/prism/releases/latest)
 [![Build](https://img.shields.io/github/actions/workflow/status/fc6a1b03/prism/build_jar.yml?branch=master)](https://github.com/fc6a1b03/prism/actions)
@@ -11,20 +11,20 @@
 # Prism Plugin
 
 Prism 是一个面向 IntelliJ IDEA 2026.2 的效率插件（原名 Json Helper），集 JSON 工具与编辑器增强于一身。  
-JSON 侧支持编辑、压缩、转义、JsonPath 查询、Java 类与 JSON 结构互转，以及 XML / YAML / TOML / Properties / CSV / XLSX 等格式转换；增强侧提供代码地图（minimap）、彩虹括号与变量高亮、颜色字面量、项目树文件注释与压缩包浏览、代码截图、项目 / HTTP / 端口搜索等能力。
+JSON 侧支持编辑、压缩、转义、JsonPath 查询、Java 类与 JSON 结构互转，以及 XML / YAML / TOML / Properties / CSV / XLSX / Markdown 等格式转换；增强侧提供代码地图（minimap）、彩虹括号与变量高亮、颜色字面量、项目树文件注释与压缩包浏览、代码截图、项目 / HTTP / 端口搜索等能力。
 
 ## 当前基线
 
 - IntelliJ IDEA: `2026.2`
 - Java: `25`
-- Gradle: `9.6.1`
+- Gradle: `9.7.0`
 - 安装方式: `build/distributions/*.zip` 自定义本地安装
 - 插件 ID: `com.acme.prism`
 
 ## 主要能力
 
 - JSON 编辑、格式化、压缩、转义与反转义
-- **自动修复损坏 JSON**（单引号/缺逗号/尾逗号/注释/JSONP 包装/裸键/非标准字面量），带置信度与修复日志
+- **自动修复损坏 JSON**（单引号/缺逗号/尾逗号/注释/JSONP 包装/裸键/非标准字面量/NDJSON 流/MongoDB 扩展 JSON 包装），带置信度与修复日志
 - **按键递归排序、扁平化/还原**（点号键与嵌套结构互转）、**JSON Schema（2020-12）生成**
 - **右侧面板深度工具**：结构分析（键/对象/数组/深度/大小统计、重复键检测）、树形面板展开全部/折叠全部、选中节点路径与完整值详情
 - 从 JSON 生成 Java Class / Record
@@ -45,7 +45,7 @@ JSON 侧支持编辑、压缩、转义、JsonPath 查询、Java 类与 JSON 结�
 
 ## 开发与打包
 
-本项目已生成 Gradle Wrapper（`gradlew` / `gradlew.bat`，固定 `9.6.1`），优先使用 `./gradlew`；也可使用系统中的 `gradle` 命令，Java 编译与运行环境固定为 `25`。
+本项目已生成 Gradle Wrapper（`gradlew` / `gradlew.bat`，固定 `9.7.0`），优先使用 `./gradlew`；也可使用系统中的 `gradle` 命令，Java 编译与运行环境固定为 `25`。
 
 ```bash
 ./gradlew printAllVersions
@@ -104,7 +104,7 @@ src/main/java/com/acme/prism
 GitHub Actions 工作流 [build_jar.yml](.github/workflows/build_jar.yml) 已适配当前基线：
 
 - 固定 `Java 25`
-- 固定 `Gradle 9.6.1`
+- 固定 `Gradle 9.7.0`
 - 运行 `test` 单元测试
 - 构建 `buildPlugin`
 - 校验 `verifyPluginProjectConfiguration` 与 `verifyPluginStructure`

--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,15 @@ intellijPlatform {
         version = project.version.toString()
         // sinceBuild 自 IGP 2.14 起默认取目标平台 major build（2026.2 → 262），无需显式声明
         changeNotes = """
+            <b>0.22.0</b>
+            <ul>
+                <li>JSON 修复扩展：MongoDB 扩展 JSON 包装剥离（NumberLong/NumberInt/Timestamp/new Date/ISODate/ObjectId/UUID/NumberDecimal/BinData，MinKey/MaxKey 转 null），新增 FixType.MONGODB 与修复日志；骨架层正则含词边界加固，字符串值内文本零误伤。</li>
+                <li>修复自动识别拦截：MongoDB 包装文本被 YAML 检测抢先消费成带引号字符串，resolveJson 新增 containsMongoWrapper 前置短路（含根因佐证与端到端单测，new Date 同步纳入签名）。</li>
+                <li>Schema 校验器补全 contains/minContains/maxContains（含 minContains=0 允许零匹配语义）、propertyNames、dependentRequired、dependentSchemas（独立校验防递归）。</li>
+                <li>新增 JSON → Markdown 表格转换：对象数组并集列头/混合数组索引值/单对象键值/标量单列，管道符与换行转义，null 输出空单元格；注册 AnyFile.MARKDOWN，转换对话框自动出现入口。</li>
+                <li>构建升级 Gradle 9.6.1 → 9.7.0：wrapper、CI 工作流、README/AGENTS.md/gradle.properties 引用同步。</li>
+                <li>新增 24 个单元测试（总 549 全绿），i18n 174 键双文件一致。</li>
+            </ul>
             <b>0.21.0</b>
             <ul>
                 <li>新增键名风格转换：JsonKeyConverter 递归转换对象键（camelCase/snake_case/PascalCase/kebab-case 两两互转），分词处理大小写边界、连续大写缩略词（HTTPServer→http_server）、字母数字边界（user2name→user_2_name）；null 值字段保留（与排序器惯例一致）；转换后键名冲突后者覆盖（JSON 重复键固有限制，类 Javadoc 明示）；工具条新增转换按钮（四种风格弹出菜单）。</li>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # ============================================================
-# Gradle 构建环境配置（依据 Gradle 9.6.1 官方属性表整理）
-# https://docs.gradle.org/9.6.1/userguide/build_environment.html
+# Gradle 构建环境配置（依据 Gradle 9.7.0 官方属性表整理）
+# https://docs.gradle.org/9.7.0/userguide/build_environment.html
 # 仅保留非默认值与项目必需项；默认值（如 daemon、vfs.watch）不再显式声明
 # ============================================================
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 // 统一版本表：插件版本、目标平台、Java 基线与第三方依赖版本在此集中维护
 gradle.ext.versions = [
         // 插件版本：发布新版本时递增，并同步更新 build.gradle 中的 changeNotes
-        ver         : "0.21.0",
+        ver         : "0.22.0",
         // 目标 IntelliJ 平台版本：sinceBuild 自 IGP 2.14 起默认取平台 major build（2026.2 → 262），无需显式声明
         idea        : "2026.2",
         // Java 语言基线：toolchain 与 options.release 共用

--- a/src/main/java/com/acme/prism/common/enums/AnyFile.java
+++ b/src/main/java/com/acme/prism/common/enums/AnyFile.java
@@ -58,6 +58,10 @@ public enum AnyFile {
      */
     BASE64,
     /**
+     * Markdown表格
+     */
+    MARKDOWN,
+    /**
      * 单文本
      */
     TEXT;
@@ -71,6 +75,7 @@ public enum AnyFile {
         return switch (this) {
             case CLASS, RECORD -> "java";
             case SQL -> "sql";
+            case MARKDOWN -> "md";
             case JSON, XML, YAML, TOML, CSV, XLSX, PROPERTIES -> this.name().toLowerCase(Locale.ROOT);
             default -> "txt";
         };

--- a/src/main/java/com/acme/prism/common/enums/SupportedLanguages.java
+++ b/src/main/java/com/acme/prism/common/enums/SupportedLanguages.java
@@ -30,7 +30,8 @@ public enum SupportedLanguages {
     BASE64(PlainTextFileType.INSTANCE, AnyFile.BASE64),
     URL_PARAMS(PlainTextFileType.INSTANCE, AnyFile.URL_PARAMS),
     SQL(PlainTextFileType.INSTANCE, AnyFile.SQL),
-    PROPERTIES(PropertiesFileType.INSTANCE, AnyFile.PROPERTIES);
+    PROPERTIES(PropertiesFileType.INSTANCE, AnyFile.PROPERTIES),
+    MARKDOWN(PlainTextFileType.INSTANCE, AnyFile.MARKDOWN);
     private static final Map<AnyFile, SupportedLanguages> BY_ANY_FILE = createIndex();
     private final AnyFile extension;
     private final LanguageFileType fileType;

--- a/src/main/java/com/acme/prism/core/json/JsonRepairer.java
+++ b/src/main/java/com/acme/prism/core/json/JsonRepairer.java
@@ -18,8 +18,8 @@ import java.util.regex.Pattern;
  *
  * <p>修复采用分层管道：BOM 剥离 → NDJSON 检测组装 → Markdown 代码块剥离 → JSONP 剥离 →
  * 日志前缀剥离 → 特殊引号规范化 → 单引号转双引号 → 裸键补引号 → 注释剥离 →
- * 字符串提取保护 → 骨架修复（逗号/字面量/闭合括号）→ 字符串还原 → 合法性验证。
- * 字符串内容在修复期间被占位符保护，避免正则误伤值内容。</p>
+ * 字符串提取保护 → MongoDB 包装剥离 → 骨架修复（逗号/字面量/闭合括号）→
+ * 字符串还原 → 合法性验证。字符串内容在修复期间被占位符保护，避免正则误伤值内容。</p>
  *
  * @author 拒绝者
  * @date 2026-08-05
@@ -69,6 +69,31 @@ public final class JsonRepairer implements JsonOperation {
      * 非标准字面量模式
      */
     private static final Pattern LITERAL = Pattern.compile("\\b(undefined|None|True|False|NaN|Infinity)\\b");
+    /**
+     * MongoDB 扩展 JSON 包装模式（骨架层匹配：字符串内容已占位化，仅结构位置生效）。
+     * <p>分组 1-4 为数字包装（直接取数字），5-10 为字符串包装（还原占位符），
+     * MinKey/MaxKey 整体匹配转 null。交替分支用非捕获组，分组编号与
+     * {@link #normalizeMongoWrapper} 对应。</p>
+     */
+    private static final Pattern MONGODB_WRAPPER = Pattern.compile(
+            "\\bNumberLong\\s*\\(\\s*(-?\\d+)\\s*\\)" +
+            "|\\bNumberInt\\s*\\(\\s*(-?\\d+)\\s*\\)" +
+            "|\\bTimestamp\\s*\\(\\s*(-?\\d+)\\s*,\\s*-?\\d+\\s*\\)" +
+            "|\\bnew\\s+Date\\s*\\(\\s*(-?\\d+)\\s*\\)" +
+            "|\\bISODate\\s*\\(\\s*(__PRISM_STR_\\d+__)\\s*\\)" +
+            "|\\bObjectId\\s*\\(\\s*(__PRISM_STR_\\d+__)\\s*\\)" +
+            "|\\bUUID\\s*\\(\\s*(__PRISM_STR_\\d+__)\\s*\\)" +
+            "|\\bNumberDecimal\\s*\\(\\s*(__PRISM_STR_\\d+__)\\s*\\)" +
+            "|\\bBinData\\s*\\(\\s*\\d+\\s*,\\s*(__PRISM_STR_\\d+__)\\s*\\)" +
+            "|\\bnew\\s+Date\\s*\\(\\s*(__PRISM_STR_\\d+__)\\s*\\)" +
+            "|\\bMinKey\\b|\\bMaxKey\\b");
+    /**
+     * MongoDB 包装特征签名（原始文本检测用：精确词边界匹配）。
+     * <p>含 {@code new Date}：误报代价为零——普通代码文本原就被 URL 参数等检测
+     * 误转或转不出 JSON，短路后行为只会更稳定，故不排除。</p>
+     */
+    private static final Pattern MONGODB_SIGNATURE = Pattern.compile(
+            "\\b(?:NumberLong|NumberInt|Timestamp|ISODate|ObjectId|UUID|NumberDecimal|BinData|MinKey|MaxKey)\\b|\\bnew\\s+Date\\b");
     /**
      * NDJSON 组装缩进前缀
      */
@@ -141,7 +166,11 @@ public final class JsonRepairer implements JsonOperation {
         /**
          * NDJSON 流组装为 JSON 数组
          */
-        NDJSON("json.repair.fix.ndjson", 0.10);
+        NDJSON("json.repair.fix.ndjson", 0.10),
+        /**
+         * MongoDB 扩展 JSON 包装剥离
+         */
+        MONGODB("json.repair.fix.mongodb", 0.10);
 
         /**
          * 修复类型 i18n 键
@@ -246,6 +275,12 @@ public final class JsonRepairer implements JsonOperation {
         // 10. 提取字符串为占位符，保护值内容
         final StringExtraction extraction = extractStrings(text);
         String skeleton = extraction.skeleton();
+        // 10.5 MongoDB 扩展 JSON 包装剥离（骨架层：字符串值内容已占位化，不会误伤）
+        final String beforeMongo = skeleton;
+        skeleton = MONGODB_WRAPPER.matcher(skeleton).replaceAll(JsonRepairer::normalizeMongoWrapper);
+        if (!skeleton.equals(beforeMongo)) {
+            fixes.add(FixType.MONGODB);
+        }
         // 11. 骨架修复（骨架无字符串内容，正则安全）
         final String beforeTrailing = skeleton;
         skeleton = TRAILING_COMMA.matcher(skeleton).replaceAll("$1");
@@ -299,6 +334,18 @@ public final class JsonRepairer implements JsonOperation {
     public String process(final String json) {
         final RepairResult result = repair(json);
         return Objects.isNull(result) ? json : result.json();
+    }
+
+    /**
+     * 检测文本是否含 MongoDB 扩展 JSON 包装特征（精确词边界，供格式自动识别前置判断，
+     * 避免被 YAML 检测抢先消费）。含 {@code new Date}：普通代码文本原就被 URL 参数等
+     * 检测误转或转不出 JSON，短路后行为只会更稳定，无破坏面。
+     *
+     * @param text 输入文本
+     * @return 是否含 MongoDB 包装特征
+     */
+    public static boolean containsMongoWrapper(final String text) {
+        return StrUtil.isNotBlank(text) && MONGODB_SIGNATURE.matcher(text).find();
     }
 
     /**
@@ -752,6 +799,29 @@ public final class JsonRepairer implements JsonOperation {
         }
         sb.append(skeleton, cursor, skeleton.length());
         return sb.toString();
+    }
+
+    /**
+     * MongoDB 包装规范化替换：数字包装返回数字，字符串包装返回占位符引用，
+     * MinKey/MaxKey 转为 null。
+     *
+     * @param match 匹配结果
+     * @return 规范化后的值
+     */
+    private static String normalizeMongoWrapper(final MatchResult match) {
+        for (int group = 1; group <= 4; group++) {
+            final String number = match.group(group);
+            if (Objects.nonNull(number)) {
+                return number;
+            }
+        }
+        for (int group = 5; group <= 10; group++) {
+            final String placeholder = match.group(group);
+            if (Objects.nonNull(placeholder)) {
+                return placeholder;
+            }
+        }
+        return "null";
     }
 
     /**

--- a/src/main/java/com/acme/prism/core/json/JsonSchemaValidator.java
+++ b/src/main/java/com/acme/prism/core/json/JsonSchemaValidator.java
@@ -28,6 +28,7 @@ import java.util.regex.PatternSyntaxException;
  * <p>支持关键字：type（含多类型数组）、required、properties、items、enum、minLength/maxLength、
  * minimum/maximum、pattern、format（email/date-time/date/time/uri/uuid/ipv4/ipv6）、
  * oneOf/anyOf/allOf/not、if/then/else、minItems/maxItems/uniqueItems、minProperties/maxProperties、
+ * contains/minContains/maxContains、propertyNames、dependentRequired、dependentSchemas、
  * exclusiveMinimum/exclusiveMaximum、multipleOf。输出每个失败项（路径/期望/实际/说明）
  * 与已校验字段总数。</p>
  *
@@ -412,6 +413,46 @@ public final class JsonSchemaValidator {
                 }
             }
         }
+        // propertyNames：所有键名均需匹配子 schema（键名作为字符串值独立校验）
+        final Object propertyNames = schemaNode.get("propertyNames");
+        if (propertyNames instanceof final JSONObject namesSchema) {
+            for (final String key : obj.keySet()) {
+                if (!checkMatches(key, namesSchema, path)) {
+                    issues.add(new ValidationIssue(path, "键名满足 propertyNames 约束", key, "键名不满足 propertyNames"));
+                }
+            }
+        }
+        // dependentRequired：存在触发键时联动必填其他键（2020-12 语义）
+        final JSONObject dependentRequired = schemaNode.getJSONObject("dependentRequired");
+        if (Objects.nonNull(dependentRequired)) {
+            for (final String trigger : dependentRequired.keySet()) {
+                if (!obj.containsKey(trigger)) {
+                    continue;
+                }
+                final JSONArray requires = dependentRequired.getJSONArray(trigger);
+                if (Objects.isNull(requires)) {
+                    continue;
+                }
+                for (final Object item : requires) {
+                    final String requiredKey = Convert.toStr(item);
+                    if (!obj.containsKey(requiredKey)) {
+                        issues.add(new ValidationIssue(path,
+                                "存在 %s 时必填 %s".formatted(trigger, requiredKey), "缺失", "dependentRequired 约束不满足"));
+                    }
+                }
+            }
+        }
+        // dependentSchemas：存在触发键时整个对象需满足对应子 schema（独立校验避免递归，与 not 一致）
+        final JSONObject dependentSchemas = schemaNode.getJSONObject("dependentSchemas");
+        if (Objects.nonNull(dependentSchemas)) {
+            for (final String trigger : dependentSchemas.keySet()) {
+                if (obj.containsKey(trigger) && dependentSchemas.get(trigger) instanceof final JSONObject depSchema
+                        && !checkMatches(obj, depSchema, path)) {
+                    issues.add(new ValidationIssue(path,
+                            "存在 %s 时满足依赖 schema".formatted(trigger), "不满足", "dependentSchemas 约束不满足"));
+                }
+            }
+        }
     }
 
     /**
@@ -469,6 +510,36 @@ public final class JsonSchemaValidator {
                 validateValue(arr.get(index), itemSchema, "%s[%d]".formatted(path, index), issues, checked);
             }
         }
+        // contains/minContains/maxContains：2020-12 包含约束（minContains 缺省 1，0 时允许零匹配）
+        final Object contains = schemaNode.get("contains");
+        if (contains instanceof final JSONObject containsSchema) {
+            final long matched = countContainsMatches(arr, containsSchema, path);
+            final int minContains = Objects.requireNonNullElse(schemaNode.getInteger("minContains"), 1);
+            final int effectiveMin = minContains == 0 ? 0 : Math.max(minContains, 1);
+            if (matched < effectiveMin) {
+                issues.add(new ValidationIssue(path, "至少 %d 个元素匹配 contains".formatted(effectiveMin),
+                        "匹配 " + matched + " 个", "contains 约束不满足"));
+            }
+            final Integer maxContains = schemaNode.getInteger("maxContains");
+            if (Objects.nonNull(maxContains) && matched > maxContains) {
+                issues.add(new ValidationIssue(path, "至多 %d 个元素匹配 contains".formatted(maxContains),
+                        "匹配 " + matched + " 个", "maxContains 约束不满足"));
+            }
+        }
+    }
+
+    /**
+     * 统计数组元素中匹配 contains 子 schema 的数量（独立校验，不污染主失败项与计数）。
+     *
+     * @param arr    数组
+     * @param schema 子 schema
+     * @param path   路径
+     * @return 匹配元素数量
+     */
+    private static long countContainsMatches(final JSONArray arr, final JSONObject schema, final String path) {
+        return arr.stream()
+                .filter(element -> checkMatches(element, schema, path))
+                .count();
     }
 
     /**

--- a/src/main/java/com/acme/prism/core/parser/JsonParser.java
+++ b/src/main/java/com/acme/prism/core/parser/JsonParser.java
@@ -58,6 +58,7 @@ public class JsonParser {
         register(converters, AnyFile.URL_PARAMS, new UrlParamsConverter());
         register(converters, AnyFile.PROPERTIES, new PropertiesConverter());
         register(converters, AnyFile.SQL, new SqlConverter());
+        register(converters, AnyFile.MARKDOWN, new MarkdownTableConverter());
         return Map.copyOf(converters);
     }
 

--- a/src/main/java/com/acme/prism/core/parser/converter/MarkdownTableConverter.java
+++ b/src/main/java/com/acme/prism/core/parser/converter/MarkdownTableConverter.java
@@ -1,0 +1,186 @@
+package com.acme.prism.core.parser.converter;
+
+import cn.hutool.core.util.StrUtil;
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONArray;
+import com.alibaba.fastjson2.JSONObject;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Markdown 表格转换器：将 JSON 转为 Markdown 表格文本。
+ *
+ * <p>转换规则：纯对象数组转并集列头表格（列头取全部对象键的首次出现顺序并集，
+ * null 值输出空单元格，对象/数组值 JSON 字符串化）；混合数组转索引/值两列表；
+ * 单对象转键/值两列表；标量转单列表。管道符转义为 {@code \|}，换行转 {@code <br>}，
+ * 保证单元格不破坏表格结构。转换失败或输入为空返回空串。</p>
+ *
+ * @author 拒绝者
+ * @date 2026-08-13
+ */
+public final class MarkdownTableConverter implements DataFormatConverter {
+
+    /**
+     * 表头分隔行单元格内容
+     */
+    private static final String HEADER_DIVIDER = "---";
+    /**
+     * 键值表头列名
+     */
+    private static final String HEADER_KEY = "Key";
+    /**
+     * 键值表头列名
+     */
+    private static final String HEADER_VALUE = "Value";
+    /**
+     * 混合数组索引列名
+     */
+    private static final String HEADER_INDEX = "Index";
+    /**
+     * 管道符转义目标
+     */
+    private static final String ESCAPED_PIPE = "\\|";
+    /**
+     * 换行转义目标（Markdown 单元格内换行）
+     */
+    private static final String ESCAPED_NEWLINE = "<br>";
+
+    /**
+     * 转换 JSON 为 Markdown 表格。
+     *
+     * @param json JSON 文本
+     * @return Markdown 表格文本；输入为空或转换失败时返回空串
+     */
+    @Override
+    public String convert(final String json) {
+        if (StrUtil.isBlank(json)) {
+            return "";
+        }
+        try {
+            return switch (JSON.parse(json)) {
+                case final JSONArray arr -> arrayToTable(arr);
+                case final JSONObject obj -> objectToTable(obj);
+                default -> singleValueTable(json);
+            };
+        } catch (final Exception ignored) {
+            return "";
+        }
+    }
+
+    /**
+     * 数组转表格：纯对象数组转键列表，混合数组转索引/值两列表（避免非对象元素丢失）。
+     *
+     * @param arr 数组
+     * @return Markdown 表格；空数组返回空串
+     */
+    private static String arrayToTable(final JSONArray arr) {
+        if (arr.isEmpty()) {
+            return "";
+        }
+        if (arr.stream().allMatch(JSONObject.class::isInstance)) {
+            return objectArrayToTable(arr);
+        }
+        final StringBuilder sb = new StringBuilder();
+        appendRow(sb, List.of(HEADER_INDEX, HEADER_VALUE));
+        appendRow(sb, List.of(HEADER_DIVIDER, HEADER_DIVIDER));
+        for (int index = 0; index < arr.size(); index++) {
+            appendRow(sb, List.of(String.valueOf(index), cellOf(arr.get(index))));
+        }
+        return sb.toString().stripTrailing();
+    }
+
+    /**
+     * 纯对象数组转并集列头表格。
+     *
+     * @param arr 对象数组
+     * @return Markdown 表格
+     */
+    private static String objectArrayToTable(final JSONArray arr) {
+        final Set<String> headers = new LinkedHashSet<>();
+        for (final Object item : arr) {
+            headers.addAll(((JSONObject) item).keySet());
+        }
+        final List<String> headerList = List.copyOf(headers);
+        final StringBuilder sb = new StringBuilder();
+        appendRow(sb, headerList.stream().map(MarkdownTableConverter::escapeCell).toList());
+        appendRow(sb, headerList.stream().map(_ -> HEADER_DIVIDER).toList());
+        for (final Object item : arr) {
+            final JSONObject obj = (JSONObject) item;
+            appendRow(sb, headerList.stream().map(key -> cellOf(obj.get(key))).toList());
+        }
+        return sb.toString().stripTrailing();
+    }
+
+    /**
+     * 单对象转键/值两列表格。
+     *
+     * @param obj 对象
+     * @return Markdown 表格
+     */
+    private static String objectToTable(final JSONObject obj) {
+        final StringBuilder sb = new StringBuilder();
+        appendRow(sb, List.of(HEADER_KEY, HEADER_VALUE));
+        appendRow(sb, List.of(HEADER_DIVIDER, HEADER_DIVIDER));
+        for (final String key : obj.keySet()) {
+            appendRow(sb, List.of(escapeCell(key), cellOf(obj.get(key))));
+        }
+        return sb.toString().stripTrailing();
+    }
+
+    /**
+     * 标量转单列表格。
+     *
+     * @param text 原始 JSON 文本（标量字面量）
+     * @return Markdown 表格
+     */
+    private static String singleValueTable(final String text) {
+        final StringBuilder sb = new StringBuilder();
+        appendRow(sb, List.of(HEADER_VALUE));
+        appendRow(sb, List.of(HEADER_DIVIDER));
+        appendRow(sb, List.of(escapeCell(text)));
+        return sb.toString().stripTrailing();
+    }
+
+    /**
+     * 追加一行表格（首尾管道符 + 单元格空格包裹）。
+     *
+     * @param sb    目标构建器
+     * @param cells 单元格内容
+     */
+    private static void appendRow(final StringBuilder sb, final List<String> cells) {
+        sb.append('|');
+        for (final String cell : cells) {
+            sb.append(' ').append(cell).append(" |");
+        }
+        sb.append('\n');
+    }
+
+    /**
+     * 值转单元格：null 输出空单元格，对象/数组 JSON 字符串化后转义。
+     *
+     * @param value 值
+     * @return 单元格内容
+     */
+    private static String cellOf(final Object value) {
+        if (Objects.isNull(value)) {
+            return "";
+        }
+        if (value instanceof JSONObject || value instanceof JSONArray) {
+            return escapeCell(JSON.toJSONString(value));
+        }
+        return escapeCell(String.valueOf(value));
+    }
+
+    /**
+     * 单元格转义：管道符与换行会破坏表格结构，统一转义。
+     *
+     * @param text 原文
+     * @return 转义后的单元格内容
+     */
+    private static String escapeCell(final String text) {
+        return text.replace("|", ESCAPED_PIPE).replace("\n", ESCAPED_NEWLINE);
+    }
+}

--- a/src/main/java/com/acme/prism/ui/panel/MainPanel.java
+++ b/src/main/java/com/acme/prism/ui/panel/MainPanel.java
@@ -866,6 +866,11 @@ public class MainPanel {
         if (JSON.isValid(jwtResult)) {
             return jwtResult;
         }
+        // MongoDB 扩展 JSON 包装（如 NumberLong(123)）会被 YAML 检测抢先消费成带引号字符串，
+        // 需在 AnyParser 之前短路跳过，交给修复器剥离包装
+        if (JsonRepairer.containsMongoWrapper(text)) {
+            return "";
+        }
         return AnyParser.convert(text);
     }
 

--- a/src/main/resources/messages/PrismBundle.properties
+++ b/src/main/resources/messages/PrismBundle.properties
@@ -170,6 +170,7 @@ json.repair.fix.log.prefix=Removed log prefix
 json.repair.fix.special.quote=Converted special quotes
 json.repair.fix.missing.bracket=Added missing closing brackets
 json.repair.fix.ndjson=Assembled NDJSON stream into array
+json.repair.fix.mongodb=Unwrapped MongoDB extended JSON
 
 json.key.case.convert=Convert Key Case
 json.key.case.convert.desc=Convert JSON object keys to naming style

--- a/src/main/resources/messages/PrismBundle_zh_CN.properties
+++ b/src/main/resources/messages/PrismBundle_zh_CN.properties
@@ -170,6 +170,7 @@ json.repair.fix.log.prefix=剥离日志前缀
 json.repair.fix.special.quote=转换特殊引号
 json.repair.fix.missing.bracket=补齐缺失闭合括号
 json.repair.fix.ndjson=将 NDJSON 流组装为数组
+json.repair.fix.mongodb=剥离 MongoDB 扩展 JSON 包装
 
 json.key.case.convert=键名风格转换
 json.key.case.convert.desc=将 JSON 对象键转换为目标命名风格

--- a/src/test/java/com/acme/prism/core/json/JsonRepairerTest.java
+++ b/src/test/java/com/acme/prism/core/json/JsonRepairerTest.java
@@ -301,4 +301,62 @@ class JsonRepairerTest {
         assertNotNull(result);
         assertFalse(result.fixes().contains(FixType.NDJSON));
     }
+
+    @Test
+    @DisplayName("正常：MongoDB 扩展 JSON 数字包装剥离")
+    void stripsMongoNumberWrappers() {
+        final RepairResult result = JsonRepairer.repair(
+                "{\"a\":NumberLong(123), \"b\":NumberInt(45), \"c\":new Date(1700000000), \"d\":Timestamp(1700000000, 1)}");
+        assertNotNull(result);
+        final JSONObject obj = JSON.parseObject(result.json());
+        assertEquals(123, obj.getLongValue("a"));
+        assertEquals(45, obj.getIntValue("b"));
+        assertEquals(1700000000, obj.getLongValue("c"));
+        assertEquals(1700000000, obj.getLongValue("d"));
+        assertTrue(result.fixes().contains(FixType.MONGODB));
+    }
+
+    @Test
+    @DisplayName("正常：MongoDB 字符串包装剥离为字符串")
+    void stripsMongoStringWrappers() {
+        final RepairResult result = JsonRepairer.repair(
+                "{\"id\":ObjectId(\"507f1f77bcf86cd799439011\"), \"time\":ISODate(\"2024-01-01T00:00:00Z\"), \"uid\":UUID(\"12345678-1234-1234-1234-123456789abc\")}");
+        assertNotNull(result);
+        final JSONObject obj = JSON.parseObject(result.json());
+        assertEquals("507f1f77bcf86cd799439011", obj.getString("id"));
+        assertEquals("2024-01-01T00:00:00Z", obj.getString("time"));
+        assertEquals("12345678-1234-1234-1234-123456789abc", obj.getString("uid"));
+        assertTrue(result.fixes().contains(FixType.MONGODB));
+    }
+
+    @Test
+    @DisplayName("正常：new Date 字符串日期形式剥离")
+    void stripsNewDateStringForm() {
+        final RepairResult result = JsonRepairer.repair("{\"d\": new Date(\"2024-01-01T00:00:00Z\")}");
+        assertNotNull(result);
+        final JSONObject obj = JSON.parseObject(result.json());
+        assertEquals("2024-01-01T00:00:00Z", obj.getString("d"));
+        assertTrue(result.fixes().contains(FixType.MONGODB));
+    }
+
+    @Test
+    @DisplayName("正常：MongoDB MinKey/MaxKey 转 null")
+    void normalizesMongoMinMaxKey() {
+        final RepairResult result = JsonRepairer.repair("{\"a\":MinKey, \"b\":MaxKey}");
+        assertNotNull(result);
+        final JSONObject obj = JSON.parseObject(result.json());
+        assertNull(obj.get("a"));
+        assertNull(obj.get("b"));
+        assertTrue(result.fixes().contains(FixType.MONGODB));
+    }
+
+    @Test
+    @DisplayName("边界：字符串值内的包装文本不误伤")
+    void mongoWrappersInsideStringUntouched() {
+        final RepairResult result = JsonRepairer.repair("{\"note\": \"NumberLong(123) stays\"}");
+        assertNotNull(result);
+        final JSONObject obj = JSON.parseObject(result.json());
+        assertEquals("NumberLong(123) stays", obj.getString("note"));
+        assertFalse(result.fixes().contains(FixType.MONGODB), "字符串值内的包装文本不应被剥离");
+    }
 }

--- a/src/test/java/com/acme/prism/core/json/JsonSchemaValidatorTest.java
+++ b/src/test/java/com/acme/prism/core/json/JsonSchemaValidatorTest.java
@@ -407,4 +407,96 @@ class JsonSchemaValidatorTest {
         );
         assertTrue(ok.issues().isEmpty(), "无 if 时 then 应被忽略（标准语义）");
     }
+
+    @Test
+    @DisplayName("正常：contains 至少一个元素匹配时通过")
+    void passesContains() {
+        final ValidationOutcome ok = JsonSchemaValidator.validate(
+                "{\"nums\":[1,2,\"x\"]}",
+                "{\"type\":\"object\",\"properties\":{\"nums\":{\"type\":\"array\",\"contains\":{\"type\":\"string\"}}}}"
+        );
+        assertTrue(ok.issues().isEmpty(), "数组含匹配元素应通过");
+
+        final ValidationOutcome bad = JsonSchemaValidator.validate(
+                "{\"nums\":[1,2]}",
+                "{\"type\":\"object\",\"properties\":{\"nums\":{\"type\":\"array\",\"contains\":{\"type\":\"string\"}}}}"
+        );
+        assertTrue(bad.issues().stream().anyMatch(issue -> issue.message().contains("contains")));
+    }
+
+    @Test
+    @DisplayName("正常：minContains 与 maxContains 数量约束")
+    void validatesContainsBounds() {
+        final ValidationOutcome ok = JsonSchemaValidator.validate(
+                "{\"nums\":[\"a\",\"b\"]}",
+                "{\"type\":\"object\",\"properties\":{\"nums\":{\"type\":\"array\",\"contains\":{\"type\":\"string\"},\"minContains\":2,\"maxContains\":3}}}"
+        );
+        assertTrue(ok.issues().isEmpty(), "2 个匹配在 [2,3] 区间内应通过");
+
+        final ValidationOutcome tooFew = JsonSchemaValidator.validate(
+                "{\"nums\":[\"a\",1]}",
+                "{\"type\":\"object\",\"properties\":{\"nums\":{\"type\":\"array\",\"contains\":{\"type\":\"string\"},\"minContains\":2}}}"
+        );
+        assertTrue(tooFew.issues().stream().anyMatch(issue -> issue.message().contains("contains")));
+
+        final ValidationOutcome tooMany = JsonSchemaValidator.validate(
+                "{\"nums\":[\"a\",\"b\",\"c\"]}",
+                "{\"type\":\"object\",\"properties\":{\"nums\":{\"type\":\"array\",\"contains\":{\"type\":\"string\"},\"maxContains\":2}}}"
+        );
+        assertTrue(tooMany.issues().stream().anyMatch(issue -> issue.message().contains("maxContains")));
+    }
+
+    @Test
+    @DisplayName("正常：propertyNames 校验键名格式")
+    void validatesPropertyNames() {
+        final ValidationOutcome ok = JsonSchemaValidator.validate(
+                "{\"user_name\":1}",
+                "{\"type\":\"object\",\"propertyNames\":{\"pattern\":\"^[a-z_]+$\"}}"
+        );
+        assertTrue(ok.issues().isEmpty(), "键名匹配正则应通过");
+
+        final ValidationOutcome bad = JsonSchemaValidator.validate(
+                "{\"UserName\":1}",
+                "{\"type\":\"object\",\"propertyNames\":{\"pattern\":\"^[a-z_]+$\"}}"
+        );
+        assertTrue(bad.issues().stream().anyMatch(issue -> issue.message().contains("propertyNames")));
+    }
+
+    @Test
+    @DisplayName("正常：dependentRequired 字段联动必填")
+    void validatesDependentRequired() {
+        final ValidationOutcome ok = JsonSchemaValidator.validate(
+                "{\"creditCard\":\"1234\",\"billing\":\"addr\"}",
+                "{\"type\":\"object\",\"dependentRequired\":{\"creditCard\":[\"billing\"]}}"
+        );
+        assertTrue(ok.issues().isEmpty(), "触发键存在且联动键齐全应通过");
+
+        final ValidationOutcome bad = JsonSchemaValidator.validate(
+                "{\"creditCard\":\"1234\"}",
+                "{\"type\":\"object\",\"dependentRequired\":{\"creditCard\":[\"billing\"]}}"
+        );
+        assertTrue(bad.issues().stream().anyMatch(issue -> issue.message().contains("dependentRequired")));
+
+        final ValidationOutcome noTrigger = JsonSchemaValidator.validate(
+                "{\"name\":\"x\"}",
+                "{\"type\":\"object\",\"dependentRequired\":{\"creditCard\":[\"billing\"]}}"
+        );
+        assertTrue(noTrigger.issues().isEmpty(), "触发键不存在时联动约束不生效");
+    }
+
+    @Test
+    @DisplayName("正常：dependentSchemas 存在触发键时校验依赖 schema")
+    void validatesDependentSchemas() {
+        final ValidationOutcome ok = JsonSchemaValidator.validate(
+                "{\"creditCard\":\"1234\",\"billing\":\"addr\"}",
+                "{\"type\":\"object\",\"dependentSchemas\":{\"creditCard\":{\"required\":[\"billing\"]}}}"
+        );
+        assertTrue(ok.issues().isEmpty(), "依赖 schema 满足应通过");
+
+        final ValidationOutcome bad = JsonSchemaValidator.validate(
+                "{\"creditCard\":\"1234\"}",
+                "{\"type\":\"object\",\"dependentSchemas\":{\"creditCard\":{\"required\":[\"billing\"]}}}"
+        );
+        assertTrue(bad.issues().stream().anyMatch(issue -> issue.message().contains("dependentSchemas")));
+    }
 }

--- a/src/test/java/com/acme/prism/core/parser/ResolveJsonCompositionTest.java
+++ b/src/test/java/com/acme/prism/core/parser/ResolveJsonCompositionTest.java
@@ -1,6 +1,10 @@
 package com.acme.prism.core.parser;
 
+import com.acme.prism.core.json.JsonRepairer;
+import com.acme.prism.core.json.JsonRepairer.FixType;
+import com.acme.prism.core.json.JsonRepairer.RepairResult;
 import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONObject;
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
 import org.junit.jupiter.api.DisplayName;
@@ -19,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class ResolveJsonCompositionTest {
 
     /**
-     * 模拟 MainPanel.resolveJson 的逻辑：PathParser → JwtParser → AnyParser，返回第一个合法 JSON。
+     * 模拟 MainPanel.resolveJson 的逻辑：PathParser → JwtParser → MongoDB 短路 → AnyParser，返回第一个合法 JSON。
      */
     private static String resolveJson(final String text) {
         final String pathResult = PathParser.convert(text);
@@ -29,6 +33,9 @@ class ResolveJsonCompositionTest {
         final String jwtResult = JwtParser.convert(text);
         if (JSON.isValid(jwtResult)) {
             return jwtResult;
+        }
+        if (JsonRepairer.containsMongoWrapper(text)) {
+            return "";
         }
         return AnyParser.convert(text);
     }
@@ -128,5 +135,54 @@ class ResolveJsonCompositionTest {
     @DisplayName("降级：空文本直接返回空串")
     void emptyTextReturnsEmpty() {
         assertTrue(resolveJson("").isEmpty(), "空文本应返回空串");
+    }
+
+    @Test
+    @DisplayName("短路：MongoDB 扩展 JSON 包装被 AnyParser 跳过（不转成带引号字符串）")
+    void mongoWrapperSkipsAnyParser() {
+        // 用户复现场景：粘贴 MongoDB 扩展 JSON 后，YAML 检测会抢先消费成带引号字符串，
+        // 破坏修复器输入；应短路跳过自动识别，交给修复器剥离包装
+        final String mongo = "{\"id\": ObjectId(\"507f1f77bcf86cd799439011\"), \"n\": NumberLong(123)}";
+        // 根因佐证：AnyParser 确实会将该文本当 YAML 消费（非空返回），证明短路必要
+        assertFalse(AnyParser.convert(mongo).isEmpty(),
+                "根因佐证：无短路时该文本会被 YAML 检测消费（修复前破坏行为）");
+        // 修复断言：短路生效，文本不被自动识别消费
+        assertTrue(resolveJson(mongo).isEmpty(),
+                "含 MongoDB 包装的文本应短路跳过自动识别，避免 YAML 抢先消费");
+    }
+
+    @Test
+    @DisplayName("端到端：MongoDB 包装文本短路后由修复器正确剥离包装")
+    void mongoWrapperShortCircuitedThenRepairable() {
+        // 完整链路复现用户场景：粘贴 → 自动识别短路（文本保持原样）→ 修复器剥离包装
+        final String mongo = "{\"id\": ObjectId(\"507f1f77bcf86cd799439011\"), \"n\": NumberLong(123)}";
+        assertTrue(resolveJson(mongo).isEmpty(), "自动识别应短路，文本保持原样");
+        final RepairResult result = JsonRepairer.repair(mongo);
+        assertNotNull(result, "修复器应能处理原始 MongoDB 包装文本");
+        final JSONObject obj = JSON.parseObject(result.json());
+        assertEquals("507f1f77bcf86cd799439011", obj.getString("id"), "ObjectId 应剥离为字符串");
+        assertEquals(123, obj.getLongValue("n"), "NumberLong 应剥离为数字");
+        assertTrue(result.fixes().contains(FixType.MONGODB), "修复日志应包含 MongoDB 剥离");
+    }
+
+    @Test
+    @DisplayName("短路：containsMongoWrapper 精确词边界检测")
+    void containsMongoWrapperMatchesExactNames() {
+        assertTrue(JsonRepairer.containsMongoWrapper("{\"a\": NumberLong(1)}"));
+        assertTrue(JsonRepairer.containsMongoWrapper("{\"a\": ISODate(\"2024-01-01\")}"));
+        assertTrue(JsonRepairer.containsMongoWrapper("{\"a\": ObjectId(\"x\")}"));
+        assertTrue(JsonRepairer.containsMongoWrapper("{\"a\": MinKey}"));
+        assertTrue(JsonRepairer.containsMongoWrapper("{\"a\": new Date(123)}"), "new Date 也应短路防 YAML 误判");
+        assertFalse(JsonRepairer.containsMongoWrapper("{\"a\": 1}"), "普通 JSON 不应误判");
+        assertFalse(JsonRepairer.containsMongoWrapper(""), "空文本不应误判");
+    }
+
+    @Test
+    @DisplayName("行为等价：合法 JSON 内的包装名文本不受短路影响（AnyParser 本身也跳过合法 JSON）")
+    void validJsonWithWrapperNameInStringBehavesEquivalently() {
+        // containsMongoWrapper 正则无引号感知，字符串值内的 "NumberLong(1)" 也会命中；
+        // 但该文本是合法 JSON，AnyParser 开头就会短路返回空串——两种路径结果等价，无破坏
+        final String validJson = "{\"a\": \"NumberLong(1)\"}";
+        assertTrue(resolveJson(validJson).isEmpty(), "合法 JSON 应返回空串（短路与否行为一致）");
     }
 }

--- a/src/test/java/com/acme/prism/core/parser/converter/MarkdownTableConverterTest.java
+++ b/src/test/java/com/acme/prism/core/parser/converter/MarkdownTableConverterTest.java
@@ -1,0 +1,101 @@
+package com.acme.prism.core.parser.converter;
+
+import com.acme.prism.common.enums.AnyFile;
+import com.acme.prism.core.parser.JsonParser;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Markdown 表格转换器单元测试
+ *
+ * @author 拒绝者
+ * @date 2026-08-13
+ */
+class MarkdownTableConverterTest {
+
+    private final MarkdownTableConverter converter = new MarkdownTableConverter();
+
+    @Test
+    @DisplayName("正常：对象数组转并集列头表格")
+    void convertsObjectArrayToTable() {
+        final String result = this.converter.convert("[{\"name\":\"a\",\"age\":1},{\"name\":\"b\",\"city\":\"X\"}]");
+        assertTrue(result.contains("| name | age | city |"), result);
+        assertTrue(result.contains("| a | 1 |  |"), result);
+        assertTrue(result.contains("| b |  | X |"), result);
+        assertTrue(result.contains("| --- | --- | --- |"), "应包含分隔行");
+    }
+
+    @Test
+    @DisplayName("正常：单对象转键值两列表")
+    void convertsObjectToKeyValueTable() {
+        final String result = this.converter.convert("{\"name\":\"acme\",\"age\":18}");
+        assertTrue(result.contains("| Key | Value |"), result);
+        assertTrue(result.contains("| name | acme |"), result);
+        assertTrue(result.contains("| age | 18 |"), result);
+    }
+
+    @Test
+    @DisplayName("正常：混合数组转索引值两列表")
+    void convertsMixedArrayToIndexTable() {
+        final String result = this.converter.convert("[1,\"x\",null]");
+        assertTrue(result.contains("| Index | Value |"), result);
+        assertTrue(result.contains("| 0 | 1 |"), result);
+        assertTrue(result.contains("| 1 | x |"), result);
+        assertTrue(result.contains("| 2 |  |"), "null 应输出空单元格");
+    }
+
+    @Test
+    @DisplayName("正常：null 值输出空单元格")
+    void nullValueProducesEmptyCell() {
+        final String result = this.converter.convert("[{\"a\":null}]");
+        assertTrue(result.contains("| a |"), result);
+        assertTrue(result.contains("|  |"), "null 单元格应为空");
+    }
+
+    @Test
+    @DisplayName("正常：单元格管道符与换行被转义")
+    void escapesPipeAndNewline() {
+        final String result = this.converter.convert("[{\"a\":\"x|y\",\"b\":\"l1\\nl2\"}]");
+        assertTrue(result.contains("x\\|y"), result);
+        assertTrue(result.contains("l1<br>l2"), result);
+    }
+
+    @Test
+    @DisplayName("正常：嵌套对象数组值 JSON 字符串化")
+    void stringifiesNestedValues() {
+        final String result = this.converter.convert("[{\"a\":{\"b\":1},\"c\":[1,2]}]");
+        assertTrue(result.contains("{\"b\":1}"), result);
+        assertTrue(result.contains("[1,2]"), result);
+    }
+
+    @Test
+    @DisplayName("正常：标量转单列表")
+    void convertsScalarToSingleColumn() {
+        final String result = this.converter.convert("42");
+        assertTrue(result.contains("| Value |"), result);
+        assertTrue(result.contains("| 42 |"), result);
+    }
+
+    @Test
+    @DisplayName("异常：空输入与非法 JSON 返回空串")
+    void returnsEmptyForBlankOrInvalid() {
+        assertEquals("", this.converter.convert(""));
+        assertEquals("", this.converter.convert("{bad"));
+    }
+
+    @Test
+    @DisplayName("异常：空数组返回空串")
+    void returnsEmptyForEmptyArray() {
+        assertEquals("", this.converter.convert("[]"));
+    }
+
+    @Test
+    @DisplayName("注册表：MARKDOWN 已接入 JsonParser 转换")
+    void registeredInJsonParser() {
+        final String result = JsonParser.convert("[{\"name\":\"acme\"}]", AnyFile.MARKDOWN);
+        assertFalse(result.isEmpty(), "注册表转换输出不应为空");
+        assertTrue(result.contains("| name |"), result);
+    }
+}


### PR DESCRIPTION
- JsonRepairer 新增 MongoDB 扩展 JSON 包装剥离（NumberLong/NumberInt/Timestamp/new Date/ISODate/ObjectId/UUID/NumberDecimal/BinData，MinKey/MaxKey 转 null），新增 FixType.MONGODB 与 i18n 修复日志；骨架层正则含词边界加固，字符串值内文本零误伤
- 修复自动识别拦截：MongoDB 包装文本被 YAML 检测抢先消费成带引号字符串，resolveJson 新增 containsMongoWrapper 前置短路（含根因佐证与端到端单测，new Date 同步纳入签名，含字符串日期形式）
- JsonSchemaValidator 补全 contains/minContains/maxContains（含 minContains=0 允许零匹配语义）、propertyNames、dependentRequired、dependentSchemas（checkMatches 独立校验防递归）
- 新增 MarkdownTableConverter：对象数组并集列头/混合数组索引值/单对象键值/标量单列，管道符与换行转义，null 输出空单元格；注册 AnyFile.MARKDOWN，转换对话框自动出现入口
- 构建升级 Gradle 9.6.1 → 9.7.0：wrapper、CI 工作流、README/AGENTS.md/gradle.properties 引用同步
- 新增 24 个单元测试（总 549 全绿），i18n 174 键双文件一致