### PR TITLE
feat: 新增 AES 密文解密与全局密钥设置，发布 0.23.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,5 +38,8 @@ bin/
 ### VS Code ###
 .vscode/
 
+### 本地测试密文（敏感数据，禁止入库） ###
+doc/测试密文.txt
+
 ### Mac OS ###
 .DS_Store

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,8 @@ src/main/
 │   │   ├── TemporalTypeHandler.java     # 时间类型处理
 │   │   └── UastSupported.java     # UAST (Universal AST) 支持
 │   ├── core/                      # 核心功能模块
+│   │   ├── crypto/                # 加密解密
+│   │   │   └── AesDecryptor.java  # AES-256-CBC 密文解密（密文 → JSON）
 │   │   ├── archive/               # 压缩包格式识别、索引、树节点、搜索、打开器、图标
 │   │   │   ├── ArchiveFormats.java      # 压缩包格式枚举与条目读取
 │   │   │   ├── ArchiveIndex.java        # 压缩包索引

--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,13 @@ intellijPlatform {
         version = project.version.toString()
         // sinceBuild 自 IGP 2.14 起默认取目标平台 major build（2026.2 → 262），无需显式声明
         changeNotes = """
+            <b>0.23.0</b>
+            <ul>
+                <li>新增 AES 密文解密：AesDecryptor（AES-256-CBC，IV 与密钥同源取前 16 字节，PKCS7 填充），工具条新增解密按钮，密文解密后格式化写回编辑器（非 JSON 明文原样写回并提示）。</li>
+                <li>兼容超长填充：部分密文尾部填充值超过块大小（如 21 字节 0x15），CryptoJS 宽松剥离而 JDK 严格模式拒绝，严格失败后回退 NoPadding 手动剥离（尾部字节一致性校验防误剥）。</li>
+                <li>密钥配置进插件全局设置（application 级，配一次所有项目通用）：设置页新增解密区（密钥输入框 + 全局配置提示），未配置密钥时解密按钮提示先配置。</li>
+                <li>新增 8 个单元测试（总 557 全绿），i18n 182 键双文件一致。</li>
+            </ul>
             <b>0.22.0</b>
             <ul>
                 <li>JSON 修复扩展：MongoDB 扩展 JSON 包装剥离（NumberLong/NumberInt/Timestamp/new Date/ISODate/ObjectId/UUID/NumberDecimal/BinData，MinKey/MaxKey 转 null），新增 FixType.MONGODB 与修复日志；骨架层正则含词边界加固，字符串值内文本零误伤。</li>

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 // 统一版本表：插件版本、目标平台、Java 基线与第三方依赖版本在此集中维护
 gradle.ext.versions = [
         // 插件版本：发布新版本时递增，并同步更新 build.gradle 中的 changeNotes
-        ver         : "0.22.0",
+        ver         : "0.23.0",
         // 目标 IntelliJ 平台版本：sinceBuild 自 IGP 2.14 起默认取平台 major build（2026.2 → 262），无需显式声明
         idea        : "2026.2",
         // Java 语言基线：toolchain 与 options.release 共用

--- a/src/main/java/com/acme/prism/core/crypto/AesDecryptor.java
+++ b/src/main/java/com/acme/prism/core/crypto/AesDecryptor.java
@@ -1,0 +1,127 @@
+package com.acme.prism.core.crypto;
+
+import cn.hutool.core.util.StrUtil;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Base64;
+
+/**
+ * AES-CBC 密文解密器：解密密文（Base64），输出明文。
+ *
+ * <p>算法约定与既有 CryptoJS 解密工具（decrypt.html）一致：密钥与 IV 同源
+ * （IV 取密钥前 16 字节，CBC 块大小）、PKCS7 填充（与 JDK {@code AES/CBC/PKCS5Padding}
+ * 对 16 字节块等价）。解密结果期望为 JSON，由调用方格式化展示。</p>
+ *
+ * <p>兼容处理：部分密文尾部填充值超过块大小（如 21 字节 0x15），
+ * CryptoJS 宽松接受并直接剥离，JDK 严格模式会拒绝——本类在严格模式失败后回退
+ * NoPadding 解密 + 手动剥离（校验尾部填充字节一致），对齐 CryptoJS 行为。</p>
+ *
+ * <p>密钥由调用方注入（插件设置），本类保持平台无关以便单元测试。</p>
+ *
+ * @author 拒绝者
+ * @date 2026-08-13
+ */
+public final class AesDecryptor {
+
+    /**
+     * CBC 块大小（字节）
+     */
+    private static final int CBC_BLOCK_SIZE = 16;
+    /**
+     * 字节无符号掩码（byte → 0~255）
+     */
+    private static final int BYTE_MASK = 0xFF;
+    /**
+     * JDK AES-CBC 严格填充算法名（PKCS5 与 CryptoJS 的 PKCS7 对 16 字节块等价）
+     */
+    private static final String ALGORITHM_PKCS5 = "AES/CBC/PKCS5Padding";
+    /**
+     * JDK AES-CBC 无填充算法名（回退路径手动剥离填充）
+     */
+    private static final String ALGORITHM_NO_PADDING = "AES/CBC/NoPadding";
+
+    private AesDecryptor() {
+    }
+
+    /**
+     * 解密 Base64 密文为明文。
+     *
+     * @param base64Cipher Base64 密文
+     * @param key          AES 密钥（UTF-8 编码后须为 16/24/32 字节）
+     * @return 明文；输入为空、密钥非法、非 Base64 或解密失败时返回 {@code null}
+     */
+    public static String decrypt(final String base64Cipher, final String key) {
+        if (StrUtil.isBlank(base64Cipher) || StrUtil.isBlank(key)) {
+            return null;
+        }
+        final byte[] keyBytes = key.getBytes(StandardCharsets.UTF_8);
+        // IV 与密钥同源：CryptoJS 显式传入 32 字节 IV 时按 CBC 块大小截取前 16 字节
+        final byte[] ivBytes = Arrays.copyOf(keyBytes, CBC_BLOCK_SIZE);
+        try {
+            final byte[] cipherBytes = Base64.getDecoder().decode(base64Cipher.trim());
+            return decryptStrict(keyBytes, ivBytes, cipherBytes);
+        } catch (final IllegalArgumentException ignored) {
+            // 非法 Base64
+            return null;
+        }
+    }
+
+    /**
+     * 严格 PKCS5 解密；填充校验失败时回退 NoPadding + 手动剥离（对齐 CryptoJS 宽松行为）。
+     *
+     * @param keyBytes    密钥字节
+     * @param ivBytes     IV 字节
+     * @param cipherBytes 密文字节
+     * @return 明文；解密失败返回 {@code null}
+     */
+    private static String decryptStrict(final byte[] keyBytes, final byte[] ivBytes, final byte[] cipherBytes) {
+        try {
+            final Cipher cipher = Cipher.getInstance(ALGORITHM_PKCS5);
+            cipher.init(Cipher.DECRYPT_MODE, new SecretKeySpec(keyBytes, "AES"), new IvParameterSpec(ivBytes));
+            return new String(cipher.doFinal(cipherBytes), StandardCharsets.UTF_8);
+        } catch (final BadPaddingException ignored) {
+            // 兼容路径：密文尾部填充值可能超过块大小（如 21 字节 0x15），
+            // CryptoJS 宽松剥离，JDK 严格模式拒绝——回退 NoPadding 手动剥离
+            return decryptLenient(keyBytes, ivBytes, cipherBytes);
+        } catch (final Exception ignored) {
+            return null;
+        }
+    }
+
+    /**
+     * 宽松解密：NoPadding 解出原始字节后按尾部填充值手动剥离（校验尾部字节一致）。
+     *
+     * @param keyBytes    密钥字节
+     * @param ivBytes     IV 字节
+     * @param cipherBytes 密文字节
+     * @return 明文；解密失败或填充结构非法返回 {@code null}
+     */
+    private static String decryptLenient(final byte[] keyBytes, final byte[] ivBytes, final byte[] cipherBytes) {
+        try {
+            final Cipher cipher = Cipher.getInstance(ALGORITHM_NO_PADDING);
+            cipher.init(Cipher.DECRYPT_MODE, new SecretKeySpec(keyBytes, "AES"), new IvParameterSpec(ivBytes));
+            final byte[] raw = cipher.doFinal(cipherBytes);
+            if (raw.length == 0) {
+                return null;
+            }
+            final int padding = raw[raw.length - 1] & BYTE_MASK;
+            if (padding < 1 || padding > raw.length) {
+                return null;
+            }
+            // 校验尾部 padding 字节全部等于填充值（防止误剥真实数据）
+            for (int i = raw.length - padding; i < raw.length; i++) {
+                if ((raw[i] & BYTE_MASK) != padding) {
+                    return null;
+                }
+            }
+            return new String(Arrays.copyOfRange(raw, 0, raw.length - padding), StandardCharsets.UTF_8);
+        } catch (final Exception ignored) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/acme/prism/core/settings/PluginSettings.java
+++ b/src/main/java/com/acme/prism/core/settings/PluginSettings.java
@@ -1,5 +1,6 @@
 package com.acme.prism.core.settings;
 
+import cn.hutool.core.util.StrUtil;
 import com.acme.prism.core.minimap.MinimapEditorFactoryListener;
 import com.intellij.ide.projectView.ProjectView;
 import com.intellij.openapi.options.Configurable;
@@ -8,7 +9,9 @@ import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.util.NlsContexts;
 import com.intellij.ui.IdeBorderFactory;
 import com.intellij.ui.components.JBCheckBox;
+import com.intellij.ui.components.JBTextField;
 import com.intellij.util.ui.FormBuilder;
+import com.intellij.util.ui.UIUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -75,7 +78,8 @@ public class PluginSettings implements Configurable {
                 || component.getRainbowBracketPair() != settings.rainbowBracketPairEnabled
                 || component.getRainbowVariable() != settings.rainbowVariableEnabled
                 || component.getColorHighlighter() != settings.colorHighlighterEnabled
-                || component.getMinimap() != settings.minimapEnabled;
+                || component.getMinimap() != settings.minimapEnabled
+                || !Objects.equals(component.getAesKey(), settings.aesKey);
     }
 
     @Override
@@ -100,6 +104,7 @@ public class PluginSettings implements Configurable {
         settings.rainbowVariableEnabled = component.getRainbowVariable();
         settings.colorHighlighterEnabled = component.getColorHighlighter();
         settings.minimapEnabled = component.getMinimap();
+        settings.aesKey = StrUtil.emptyIfNull(component.getAesKey());
         // 代码地图开关变更后同步全部已打开编辑器的挂载状态
         if (previousMinimapEnabled != settings.minimapEnabled) {
             MinimapEditorFactoryListener.syncAllEditors();
@@ -127,6 +132,7 @@ public class PluginSettings implements Configurable {
         component.setRainbowVariable(settings.rainbowVariableEnabled);
         component.setColorHighlighter(settings.colorHighlighterEnabled);
         component.setMinimap(settings.minimapEnabled);
+        component.setAesKey(settings.aesKey);
     }
 
     @Override
@@ -154,13 +160,22 @@ public class PluginSettings implements Configurable {
         private final JBCheckBox rainbowVariable = new JBCheckBox(BUNDLE.getString("plugin.setting.rainbow.variable"));
         private final JBCheckBox colorHighlighter = new JBCheckBox(BUNDLE.getString("plugin.setting.color.highlighter"));
         private final JBCheckBox minimap = new JBCheckBox(BUNDLE.getString("plugin.setting.minimap"));
+        private final JBTextField aesKey = new JBTextField();
 
         public PluginSettingsComponent() {
+            // 密钥为全局配置（application 级），配一次所有项目通用，附灰色小字提示
+            final JPanel aesKeyRow = new JPanel(new FlowLayout(FlowLayout.LEFT, 8, 0));
+            aesKey.setPreferredSize(new Dimension(300, aesKey.getPreferredSize().height));
+            final JLabel aesKeyTip = new JLabel(BUNDLE.getString("plugin.setting.aes.key.tip"));
+            aesKeyTip.setForeground(UIUtil.getContextHelpForeground());
+            aesKeyRow.add(aesKey);
+            aesKeyRow.add(aesKeyTip);
             mainPanel = FormBuilder.createFormBuilder()
                     .addComponent(of(BUNDLE.getString("plugin.setting.title1"), copyJson, jsonHelper), 1)
                     .addComponent(of(BUNDLE.getString("plugin.setting.title2"), projectSearch, httpSearch, portSearch), 1)
                     .addComponent(of(BUNDLE.getString("plugin.setting.title3"), archiveNode, fileInfoNode), 1)
                     .addComponent(of(BUNDLE.getString("plugin.setting.title4"), rainbowBracketPair, rainbowVariable, colorHighlighter, minimap), 1)
+                    .addComponent(of(BUNDLE.getString("plugin.setting.title5"), aesKeyRow), 1)
                     .addComponentFillVertically(new JPanel(), 0)
                     .getPanel();
         }
@@ -281,6 +296,14 @@ public class PluginSettings implements Configurable {
 
         public void setMinimap(final boolean status) {
             minimap.setSelected(status);
+        }
+
+        public String getAesKey() {
+            return aesKey.getText();
+        }
+
+        public void setAesKey(final String key) {
+            aesKey.setText(key);
         }
     }
 }

--- a/src/main/java/com/acme/prism/core/settings/PluginSettingsState.java
+++ b/src/main/java/com/acme/prism/core/settings/PluginSettingsState.java
@@ -48,6 +48,8 @@ public class PluginSettingsState implements PersistentStateComponent<PluginSetti
     public boolean minimapErrorStripeEnabled = Boolean.TRUE;
     /** 代码地图启用时隐藏编辑器原始滚动条（默认隐藏；关闭后恢复 AS_NEEDED） */
     public boolean minimapHideOriginalScrollBar = Boolean.TRUE;
+    /** 密文解密 AES 密钥（默认空，用户按需在设置中填写；UTF-8 编码后须为 16/24/32 字节） */
+    public String aesKey = "";
 
     @NotNull
     public static PluginSettingsState getInstance() {

--- a/src/main/java/com/acme/prism/ui/panel/MainPanel.java
+++ b/src/main/java/com/acme/prism/ui/panel/MainPanel.java
@@ -2,11 +2,13 @@ package com.acme.prism.ui.panel;
 
 import cn.hutool.core.util.StrUtil;
 import com.acme.prism.common.Clipboard;
+import com.acme.prism.core.crypto.AesDecryptor;
 import com.acme.prism.core.json.*;
 import com.acme.prism.core.notice.Notifier;
 import com.acme.prism.core.parser.AnyParser;
 import com.acme.prism.core.parser.JwtParser;
 import com.acme.prism.core.parser.PathParser;
+import com.acme.prism.core.settings.PluginSettings;
 import com.acme.prism.ui.dialog.ConvertAnyDialog;
 import com.acme.prism.ui.dialog.JsonAnalyzeDialog;
 import com.acme.prism.ui.dialog.JsonValidateDialog;
@@ -204,6 +206,8 @@ public class MainPanel {
         panel.add(this.createToolButton(BUNDLE.getString("json.mock.generate"), AllIcons.Actions.Rerun,
                 _ -> this.optJson(redoButton, undoButton, editor.getEditor(), new JsonMockGenerator())));
         panel.add(this.createKeyCaseButton(redoButton, undoButton, editor));
+        panel.add(this.createToolButton(BUNDLE.getString("json.decrypt"), AllIcons.Nodes.SecurityRole,
+                _ -> this.decryptJson(redoButton, undoButton, editor)));
         panel.add(this.createToolButton(BUNDLE.getString("json.validate"), AllIcons.General.GreenCheckmark,
                 _ -> this.showValidateDialog(editor)));
         panel.add(this.createToolButton(BUNDLE.getString("json.analyze"), AllIcons.Actions.Find,
@@ -307,6 +311,53 @@ public class MainPanel {
                         Notifier.notifyWarn("%s %s".formatted(summary, BUNDLE.getString("json.repair.low.confidence")), editor.getProject());
                     } else {
                         Notifier.notifyInfo(summary, editor.getProject());
+                    }
+                }))
+                .exceptionally(error -> {
+                    Notifier.notifyError(error.getMessage(), editor.getProject());
+                    return null;
+                });
+    }
+
+    /**
+     * 解密 JSON：编辑器内容作为 Base64 密文，用设置中的 AES 密钥解密后格式化写回
+     * （非 JSON 明文原样写回）。密钥未配置时提示去设置页填写。
+     *
+     * @param redoButton 重做按钮
+     * @param undoButton 撤消按钮
+     * @param editor     当前编辑
+     */
+    private void decryptJson(final JButton redoButton, final JButton undoButton, final EditorTextField editor) {
+        if (Objects.isNull(editor) || Objects.isNull(editor.getProject())) return;
+        final Document document = editor.getDocument();
+        final String snapshot = document.getText();
+        if (StrUtil.isBlank(snapshot)) return;
+        // 密钥来自插件设置（用户自行配置，避免密钥入库）；未配置时提示
+        final String key = PluginSettings.of().aesKey;
+        if (StrUtil.isBlank(key)) {
+            Notifier.notifyWarn(BUNDLE.getString("json.decrypt.key.empty"), editor.getProject());
+            return;
+        }
+        CompletableFuture
+                .supplyAsync(() -> AesDecryptor.decrypt(snapshot, key), AppExecutorUtil.getAppExecutorService())
+                .thenAccept(plain -> ApplicationManager.getApplication().invokeLater(() -> {
+                    if (Objects.isNull(plain)) {
+                        Notifier.notifyError(BUNDLE.getString("json.decrypt.failed"), editor.getProject());
+                        return;
+                    }
+                    if (!snapshot.equals(document.getText())) {
+                        return;
+                    }
+                    // 解密结果是合法 JSON 则格式化（树面板可浏览），否则原样写回明文
+                    final boolean isJson = JSON.isValid(plain);
+                    final String result = isJson ? new JsonFormatter().process(plain) : plain;
+                    WriteCommandAction.runWriteCommandAction(editor.getProject(), () -> {
+                        this.pushHistory(this.undoStack, snapshot);
+                        document.setText(result);
+                        this.updateButtons(undoButton, redoButton);
+                    });
+                    if (!isJson) {
+                        Notifier.notifyWarn(BUNDLE.getString("json.decrypt.non.json"), editor.getProject());
                     }
                 }))
                 .exceptionally(error -> {

--- a/src/main/resources/messages/PrismBundle.properties
+++ b/src/main/resources/messages/PrismBundle.properties
@@ -86,6 +86,9 @@ archive.search.group.name=Archives
 archive.entry.too.large=Entry too large to open (over 8 MB)
 archive.entry.open.failed=Failed to open archive entry
 plugin.setting.title4=Editor
+plugin.setting.title5=Decryption
+plugin.setting.aes.key=AES Key
+plugin.setting.aes.key.tip=Global setting, applies to all projects
 plugin.setting.rainbow.bracket.pair=Rainbow Bracket Pair
 plugin.setting.rainbow.variable=Rainbow Variables (color parameters & local variables by name)
 plugin.setting.color.highlighter=Color Literal Blocks (#RRGGBB / rgb())
@@ -178,5 +181,11 @@ json.key.case.camel=camelCase
 json.key.case.snake=snake_case
 json.key.case.pascal=PascalCase
 json.key.case.kebab=kebab-case
+
+json.decrypt=Decrypt Cipher
+json.decrypt.desc=Decrypt AES ciphertext to JSON
+json.decrypt.failed=Decryption failed, please check the ciphertext
+json.decrypt.key.empty=Please configure the AES key in Settings first (Tools → Prism)
+json.decrypt.non.json=Decryption succeeded, but the result is not JSON
 
 json.tool.empty.editor=Please enter JSON content in the editor first

--- a/src/main/resources/messages/PrismBundle_zh_CN.properties
+++ b/src/main/resources/messages/PrismBundle_zh_CN.properties
@@ -86,6 +86,9 @@ archive.search.group.name=压缩包
 archive.entry.too.large=条目过大无法打开（超过 8 MB）
 archive.entry.open.failed=压缩包条目打开失败
 plugin.setting.title4=编辑器
+plugin.setting.title5=密文解密
+plugin.setting.aes.key=AES 密钥
+plugin.setting.aes.key.tip=全局配置，配置一次所有项目通用
 plugin.setting.rainbow.bracket.pair=彩虹括号配对高亮
 plugin.setting.rainbow.variable=彩虹变量高亮（方法内参数与局部变量按名着色）
 plugin.setting.color.highlighter=颜色字面量色块（#RRGGBB / rgb()）
@@ -178,5 +181,11 @@ json.key.case.camel=小驼峰（camelCase）
 json.key.case.snake=下划线（snake_case）
 json.key.case.pascal=大驼峰（PascalCase）
 json.key.case.kebab=连字符（kebab-case）
+
+json.decrypt=解密密文
+json.decrypt.desc=解密 AES 密文为 JSON
+json.decrypt.failed=解密失败，请检查密文
+json.decrypt.key.empty=请先在设置中配置 AES 密钥（工具 → Prism）
+json.decrypt.non.json=解密成功，但结果不是 JSON
 
 json.tool.empty.editor=请先在编辑器中输入 JSON 内容

--- a/src/test/java/com/acme/prism/core/crypto/AesDecryptorTest.java
+++ b/src/test/java/com/acme/prism/core/crypto/AesDecryptorTest.java
@@ -1,0 +1,170 @@
+package com.acme.prism.core.crypto;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Base64;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * AES-256-CBC 密文解密器单元测试
+ *
+ * @author 拒绝者
+ * @date 2026-08-13
+ */
+class AesDecryptorTest {
+
+    /**
+     * 测试专用密钥（32 字节 ASCII，与生产密钥无关，仅供单测）
+     */
+    private static final String KEY = "UnitTestAesKey1234567890abcdefgh";
+    /**
+     * CBC 块大小（字节）
+     */
+    private static final int CBC_BLOCK_SIZE = 16;
+    /**
+     * JDK AES-CBC 算法名
+     */
+    private static final String ALGORITHM = "AES/CBC/PKCS5Padding";
+
+    @Test
+    @DisplayName("互操作：openssl 生成的密文可解密（与 CryptoJS 同语义）")
+    void decryptsOpensslVector() {
+        // 向量来源：openssl enc -aes-256-cbc -K <测试密钥hex> -iv <前16字节hex> -nosalt -base64
+        // CryptoJS 显式传 iv 时同样输出纯 ciphertext 且 IV 截断为块大小，两者互操作等价
+        final String cipher = "I2jDBv/3m2+Ha924OxDhT/6wUZyzr2pj8riSoheQFxM=";
+        final String plain = AesDecryptor.decrypt(cipher, KEY);
+        assertNotNull(plain, "合法密文应解密成功");
+        assertEquals("{\"name\":\"张三\",\"age\":18}", plain);
+    }
+
+    @Test
+    @DisplayName("正常：round-trip 加密后解密还原")
+    void roundTrip() {
+        final String plain = "{\"data\":[1,2,3],\"ok\":true}";
+        final String cipher = encrypt(plain);
+        assertEquals(plain, AesDecryptor.decrypt(cipher, KEY), "加密后解密应还原原文");
+    }
+
+    @Test
+    @DisplayName("正常：密文两端空白可容忍")
+    void toleratesSurroundingWhitespace() {
+        final String cipher = encrypt("{\"a\":1}");
+        assertEquals("{\"a\":1}", AesDecryptor.decrypt("  " + cipher + "\n", KEY));
+    }
+
+    @Test
+    @DisplayName("边界：空输入返回 null")
+    void returnsNullForBlankInput() {
+        assertNull(AesDecryptor.decrypt(null, KEY));
+        assertNull(AesDecryptor.decrypt("", KEY));
+        assertNull(AesDecryptor.decrypt("   ", KEY));
+        assertNull(AesDecryptor.decrypt("cipher", null), "密钥为空应返回 null");
+        assertNull(AesDecryptor.decrypt("cipher", ""), "密钥为空应返回 null");
+    }
+
+    @Test
+    @DisplayName("边界：非 Base64 输入返回 null")
+    void returnsNullForInvalidBase64() {
+        assertNull(AesDecryptor.decrypt("!!!not-base64!!!", KEY));
+    }
+
+    @Test
+    @DisplayName("边界：密钥不匹配的密文返回 null（填充校验失败）")
+    void returnsNullForWrongKey() {
+        // 用错误密钥加密的密文，解密时 PKCS5 填充校验失败，应返回 null 而非抛异常
+        final String wrongKeyCipher = encryptWithKey("{\"a\":1}", "WrongKeyWrongKeyWrongKeyWrongKey");
+        assertNull(AesDecryptor.decrypt(wrongKeyCipher, KEY));
+    }
+
+    /**
+     * 超长填充值（0x15 = 21，超过块大小，模拟超长填充兼容场景）
+     */
+    private static final int OVERSIZED_PADDING = 0x15;
+    /**
+     * 篡改测试：翻转距密文末尾的偏移量（落在填充区，破坏填充一致性）
+     */
+    private static final int TAMPER_OFFSET_FROM_END = 9;
+
+    @Test
+    @DisplayName("兼容：超长填充值密文可解密（对齐 CryptoJS 宽松行为）")
+    void decryptsOversizedPadding() {
+        // 真实场景：尾部填充值 21（0x15）超过 16 块大小，JDK 严格模式拒绝，
+        // CryptoJS 宽松剥离；本类应回退 NoPadding 手动剥离成功
+        // 明文长度须 %16==11，使"明文 + 21 字节填充"恰好块对齐（NoPadding 加密要求）
+        final String plain = "{\"ok\":true}";
+        assertEquals(11, plain.length(), "测试前置：明文长度 %16 应等于 11");
+        final String cipher = encryptWithOversizedPadding(plain);
+        assertEquals(plain, AesDecryptor.decrypt(cipher, KEY),
+                "超长填充值密文应走兼容路径并正确剥离");
+    }
+
+    @Test
+    @DisplayName("兼容：超长填充尾部字节不一致时不误剥（返回 null）")
+    void rejectsInconsistentOversizedPadding() {
+        // 尾部声明填充 21 但实际字节不全为 0x15：手动剥离校验应拒绝，不误剥真实数据
+        final String plain = "{\"ok\":true}";
+        final String cipher = encryptWithOversizedPadding(plain);
+        // 篡改密文使尾部填充结构非法（翻转落在填充区的某一字节）
+        final byte[] raw = Base64.getDecoder().decode(cipher);
+        raw[raw.length - TAMPER_OFFSET_FROM_END] ^= 0x01;
+        final String tampered = Base64.getEncoder().encodeToString(raw);
+        assertNull(AesDecryptor.decrypt(tampered, KEY), "填充结构非法的密文应返回 null");
+    }
+
+    /**
+     * 用 NoPadding 加密"明文 + 21 字节 0x15"（模拟超长填充密文）。
+     *
+     * @param plain 明文（长度须满足 {@code len % 16 == 11}，保证总长块对齐）
+     * @return Base64 密文
+     */
+    private static String encryptWithOversizedPadding(final String plain) {
+        try {
+            final byte[] keyBytes = KEY.getBytes(StandardCharsets.UTF_8);
+            final byte[] ivBytes = Arrays.copyOf(keyBytes, CBC_BLOCK_SIZE);
+            final byte[] plainBytes = plain.getBytes(StandardCharsets.UTF_8);
+            final byte[] padded = Arrays.copyOf(plainBytes, plainBytes.length + OVERSIZED_PADDING);
+            Arrays.fill(padded, plainBytes.length, padded.length, (byte) OVERSIZED_PADDING);
+            final Cipher cipher = Cipher.getInstance("AES/CBC/NoPadding");
+            cipher.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(keyBytes, "AES"), new IvParameterSpec(ivBytes));
+            return Base64.getEncoder().encodeToString(cipher.doFinal(padded));
+        } catch (final Exception e) {
+            throw new IllegalStateException("测试加密失败", e);
+        }
+    }
+
+    /**
+     * 用固定密钥加密明文（IV = 密钥前 16 字节）。
+     *
+     * @param plain 明文
+     * @return Base64 密文
+     */
+    private static String encrypt(final String plain) {
+        return encryptWithKey(plain, KEY);
+    }
+
+    /**
+     * 用指定密钥加密明文（IV = 密钥前 16 字节）。
+     *
+     * @param plain 明文
+     * @param key   密钥
+     * @return Base64 密文
+     */
+    private static String encryptWithKey(final String plain, final String key) {
+        try {
+            final byte[] keyBytes = key.getBytes(StandardCharsets.UTF_8);
+            final byte[] ivBytes = Arrays.copyOf(keyBytes, CBC_BLOCK_SIZE);
+            final Cipher cipher = Cipher.getInstance(ALGORITHM);
+            cipher.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(keyBytes, "AES"), new IvParameterSpec(ivBytes));
+            return Base64.getEncoder().encodeToString(cipher.doFinal(plain.getBytes(StandardCharsets.UTF_8)));
+        } catch (final Exception e) {
+            throw new IllegalStateException("测试加密失败", e);
+        }
+    }
+}


### PR DESCRIPTION
- 新增 AesDecryptor（AES-256-CBC，IV=key 前 16 字节，PKCS7）：工具条新增解密按钮（SecurityRole 图标），密文解密后格式化写回编辑器（非 JSON 明文原样写回并提示）
- 兼容超长填充（填充值超块大小如 21 字节 0x15）：CryptoJS 宽松剥离 vs JDK 严格拒绝，严格失败回退 NoPadding 手动剥离（尾部字节一致性校验防误剥）
- 密钥配置进插件全局设置（application 级，配一次所有项目通用）：设置页新增解密区（输入框 + 全局配置提示），未配置时解密按钮提示；真实密钥不入库，测试用专用测试密钥
- 新增 8 个单元测试（总 557 全绿），i18n 182 键双文件一致