### PR TITLE
fix: 修复校验弹窗布局与代码地图弹窗兼容，发布 0.23.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,11 @@ intellijPlatform {
         version = project.version.toString()
         // sinceBuild 自 IGP 2.14 起默认取目标平台 major build（2026.2 → 262），无需显式声明
         changeNotes = """
+            <b>0.23.1</b>
+            <ul>
+                <li>修复校验弹窗布局：目标 JSON 区固定高度（超高内部滚动），大 JSON 不再撑高挤掉 Schema 与结果面板。</li>
+                <li>修复代码地图兼容：弹窗（校验/转换对话框）内编辑器不挂 minimap（创建时判定 + 显示事件裁决双保险，含滚动条恢复），主编辑器不受影响。</li>
+            </ul>
             <b>0.23.0</b>
             <ul>
                 <li>新增 AES 密文解密：AesDecryptor（AES-256-CBC，IV 与密钥同源取前 16 字节，PKCS7 填充），工具条新增解密按钮，密文解密后格式化写回编辑器（非 JSON 明文原样写回并提示）。</li>

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 // 统一版本表：插件版本、目标平台、Java 基线与第三方依赖版本在此集中维护
 gradle.ext.versions = [
         // 插件版本：发布新版本时递增，并同步更新 build.gradle 中的 changeNotes
-        ver         : "0.23.0",
+        ver         : "0.23.1",
         // 目标 IntelliJ 平台版本：sinceBuild 自 IGP 2.14 起默认取平台 major build（2026.2 → 262），无需显式声明
         idea        : "2026.2",
         // Java 语言基线：toolchain 与 options.release 共用

--- a/src/main/java/com/acme/prism/core/minimap/MinimapEditorFactoryListener.java
+++ b/src/main/java/com/acme/prism/core/minimap/MinimapEditorFactoryListener.java
@@ -12,6 +12,8 @@ import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
 import java.awt.*;
+import java.awt.event.HierarchyEvent;
+import java.awt.event.HierarchyListener;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
@@ -40,6 +42,11 @@ public final class MinimapEditorFactoryListener implements EditorFactoryListener
         if (Objects.isNull(project) || !PluginSettingsState.getInstance().minimapEnabled) {
             return;
         }
+        // 弹窗（校验/转换对话框）内编辑器不挂 minimap：高度受限且无导航价值；
+        // 创建时组件可能尚未挂入窗口，漏判场景由 createPanel 的 EDT 事件裁决兜底移除
+        if (isInDialog(editor)) {
+            return;
+        }
         PANELS.computeIfAbsent(editor, e -> createPanel(e, project));
     }
 
@@ -56,7 +63,8 @@ public final class MinimapEditorFactoryListener implements EditorFactoryListener
         final var enabled = PluginSettingsState.getInstance().minimapEnabled;
         for (final var editor : com.intellij.openapi.editor.EditorFactory.getInstance().getAllEditors()) {
             final var project = editor.getProject();
-            if (Objects.isNull(project)) {
+            // 弹窗内编辑器跳过：不补挂 minimap（Prism 工具窗口主编辑器属主窗口，不受影响）
+            if (Objects.isNull(project) || isInDialog(editor)) {
                 continue;
             }
             if (enabled) {
@@ -73,10 +81,23 @@ public final class MinimapEditorFactoryListener implements EditorFactoryListener
     public static void syncScrollBarVisibility() {
         final var hide = PluginSettingsState.getInstance().minimapHideOriginalScrollBar;
         for (final var editor : com.intellij.openapi.editor.EditorFactory.getInstance().getAllEditors()) {
-            if (Objects.nonNull(editor.getProject())) {
+            // 弹窗内编辑器无 minimap，不隐藏其滚动条
+            if (Objects.nonNull(editor.getProject()) && !isInDialog(editor)) {
                 applyScrollBarVisibility(editor, hide);
             }
         }
+    }
+
+    /**
+     * 编辑器是否位于弹窗（{@link Dialog}）内，如校验/转换对话框的 EditorTextField。
+     * <p>按顶层窗口类型判定：弹窗顶层为 JDialog，Prism 工具窗口与 IDE 编辑区顶层为
+     * 主窗口（JFrame），可精确区分。弹窗编辑器不挂 minimap、不隐藏其原始滚动条。</p>
+     *
+     * @param editor 编辑器
+     * @return 是否位于弹窗内
+     */
+    private static boolean isInDialog(@NotNull final Editor editor) {
+        return SwingUtilities.getWindowAncestor(editor.getComponent()) instanceof Dialog;
     }
 
     /**
@@ -140,12 +161,38 @@ public final class MinimapEditorFactoryListener implements EditorFactoryListener
         panelRef.set(panel);
         editor.getComponent().add(panel, BorderLayout.LINE_END);
         applyScrollBarVisibility(editor, PluginSettingsState.getInstance().minimapHideOriginalScrollBar);
-        // EditorTextField（Prism 面板）、diff 视图等在 editorCreated 之后才完成自身滚动条配置
-        //（策略与尺寸初始化会覆盖宽度归零），EDT 队尾补应用一次，保证默认隐藏不依赖创建时机
+        // ① EditorTextField（Prism 面板）、diff 视图等在 editorCreated 之后才完成自身滚动条配置
+        //（策略与尺寸初始化会覆盖宽度归零），EDT 队尾补应用一次，保证默认隐藏不依赖创建时机；
+        // ② 弹窗编辑器在 editorCreated 时组件可能尚未挂入窗口（isInDialog 漏判），已挂载 minimap——
+        // 组件未显示时挂 SHOWING_CHANGED 监听，窗口显示瞬间裁决：在弹窗内则移除 minimap（含恢复滚动条）
         SwingUtilities.invokeLater(() -> {
-            if (!editor.isDisposed() && PANELS.containsKey(editor)) {
-                applyScrollBarVisibility(editor, PluginSettingsState.getInstance().minimapHideOriginalScrollBar);
+            if (editor.isDisposed() || !PANELS.containsKey(editor)) {
+                return;
             }
+            if (editor.getComponent().isShowing()) {
+                if (isInDialog(editor)) {
+                    removePanel(editor);
+                } else {
+                    applyScrollBarVisibility(editor, PluginSettingsState.getInstance().minimapHideOriginalScrollBar);
+                }
+                return;
+            }
+            editor.getComponent().addHierarchyListener(new HierarchyListener() {
+                @Override
+                public void hierarchyChanged(final HierarchyEvent e) {
+                    if ((e.getChangeFlags() & HierarchyEvent.SHOWING_CHANGED) != 0
+                            && editor.getComponent().isShowing()
+                            && !editor.isDisposed()
+                            && PANELS.containsKey(editor)) {
+                        if (isInDialog(editor)) {
+                            removePanel(editor);
+                        } else {
+                            applyScrollBarVisibility(editor, PluginSettingsState.getInstance().minimapHideOriginalScrollBar);
+                        }
+                        editor.getComponent().removeHierarchyListener(this);
+                    }
+                }
+            });
         });
         return panel;
     }

--- a/src/main/java/com/acme/prism/ui/dialog/JsonValidateDialog.java
+++ b/src/main/java/com/acme/prism/ui/dialog/JsonValidateDialog.java
@@ -58,6 +58,14 @@ public class JsonValidateDialog extends DialogWrapper {
      */
     private static final int RESULT_TABLE_MIN_HEIGHT = 140;
     /**
+     * 校验目标 JSON 区高度（像素）：固定上限防止大 JSON 内容撑高 NORTH 区挤掉下方面板
+     */
+    private static final int TARGET_JSON_HEIGHT = 200;
+    /**
+     * 校验目标 JSON 区最小高度（像素）
+     */
+    private static final int TARGET_JSON_MIN_HEIGHT = 120;
+    /**
      * 加载语言资源文件
      */
     private static final ResourceBundle BUNDLE = ResourceBundle.getBundle("messages.PrismBundle");
@@ -122,7 +130,11 @@ public class JsonValidateDialog extends DialogWrapper {
         panel.add(new JLabel(BUNDLE.getString("json.validate.target")), BorderLayout.NORTH);
         this.jsonViewer = this.createEditor(Boolean.FALSE);
         this.jsonViewer.setText(this.jsonText);
-        panel.add(new JBScrollPane(this.jsonViewer), BorderLayout.CENTER);
+        // 固定高度上限：内容超高时内部滚动，防止大 JSON 撑高 NORTH 区挤掉 Schema/结果面板
+        final JBScrollPane viewerScroll = new JBScrollPane(this.jsonViewer);
+        viewerScroll.setPreferredSize(new Dimension(0, TARGET_JSON_HEIGHT));
+        viewerScroll.setMinimumSize(new Dimension(0, TARGET_JSON_MIN_HEIGHT));
+        panel.add(viewerScroll, BorderLayout.CENTER);
         return panel;
     }
 


### PR DESCRIPTION
- 校验弹窗目标 JSON 区固定高度（200px 优先/120px 最小，超高内部滚动），大 JSON 不再撑高挤掉 Schema 与结果面板
- 代码地图弹窗兼容：校验/转换对话框内编辑器不挂 minimap（创建时 JDialog 判定 + 显示事件裁决双保险，移除时恢复滚动条），主编辑器不受影响